### PR TITLE
updated readme, and cd back up to root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # rive-wasm
+
 Wasm/JS runtime for Rive
 
+## submodules
+
+This repository uses submodules. To clone it, you can run the following:
+
+`git clone --recurse-submodules git@github.com:rive-app/rive-wasm.git`
+
 ## building
+
 Rive's Wasm build requires a patched version of Emscripten so that it can take full advantage of the ```no-rtti``` compiler directive, which helps to keep the runtime size small.
 
-Run the ```setup_build_tools.sh``` to download, configure, and compile Emscripten, and then run ```custom_emcc/emsdk/emsdk_env.sh``` to activate the tool chain environment.
+Run ```source setup_build_tools.sh``` from the root folder of the repository to download, configure, and compile Emscripten. The script will also set environment variables, now you can build the Wasm/js runtimes by running ```./build.sh```.
 
-With that in place, run ```./build.sh``` to build the Wasm/js runtime.
+If you start a new terminal, you will need to run `source setup_build_tools.sh` again before running `./build.sh`.

--- a/setup_build_tools.sh
+++ b/setup_build_tools.sh
@@ -23,11 +23,12 @@ then
     # git fetch dans
     # git checkout -b dansmaster --track dans/master
     # get closure compiler
-    npm install
-    cd ../../
+    # npm install
+    cd ../../../../
 else
     cd emsdk
     source ./emsdk_env.sh
+    cd ../../
 fi
 
 # Note that you'll need to cd into custom_emcc/emsdk and run source


### PR DESCRIPTION
PR to update readme instructions

using `source setup_build_tools.sh` to set the environment variables in the terminal when running the setup, so you can run build.sh directly after

also cding up back to the base directory.