### PR TITLE
Add support for Webworker

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,7 +1,5 @@
-var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-
 function makeMatrix(m2d) {
-    var m = svg.createSVGMatrix();
+    const m = new DOMMatrix();
     m.a = m2d.xx;
     m.b = m2d.xy;
     m.c = m2d.yx;

--- a/publish/README.md
+++ b/publish/README.md
@@ -19,3 +19,88 @@ As with all npm packages, there's a freely available CDN via unpkg.com:
     Rive({
          locateFile: (file) => 'https://unpkg.com/rive-canvas@0.6.9/'+file,
     }).then(...)
+
+## Webworker
+You can use the `rive-canvas` inside a WebWorker to dissociate it from the main thread.
+
+### OffscreenCanvas
+In your main thread get the canvas element and transfer its control to an `OffscreenCanvas` :
+```typescript
+const el = document.getElemetById('rive');
+if ('OffscreenCanvas' in window) {
+    const canvas = el.transferControlToOffscreen();
+    const ctx = this.canvas.getContext('2d');
+    // Create a worker (see below)
+    const worker = new Worker('rive.worker.js', { type: 'module'});
+    // Create OffscreenCanvas & transfer it the canvas control
+    const canvas = this.el.nativeElement.transferControlToOffscreen();
+    const url = `assets/rive/knight.riv`;
+    const animations = ['idle'];
+    worker.postMessage({ canvas, url, animations }, [canvas]);
+} else {
+    // Do as usual
+}
+```
+
+To learn more about `OffscreenCanvas` checkout this [article](https://developers.google.com/web/updates/2018/08/offscreen-canvas).
+
+### Worker
+Create a file `rive.worker.js` in which we are going to run the animation.
+```typescript
+import Rive from 'rive-canvas';
+
+addEventListener('message', async ({ data }) => {
+    const { canvas, url, animations } = data;
+
+    // Load .riv file
+    const req = new Request(url);
+    const loadRive = Rive({ locateFile: (file: string) => 'https://unpkg.com/rive-canvas@latest/' + file, });
+    const loadFile = fetch(req).then((res) => res.arrayBuffer());
+    const [ rive, buf ] = await Promise.all([ loadRive, loadFile ]);
+    const file = rive.load(new Uint8Array(buf));
+    const artboard = file.defaultArtboard();
+
+    // Associate CanvasRenderer with offset context
+    const ctx = canvas.getContext('2d');
+    const renderer = new rive.CanvasRenderer(ctx);
+
+    // Move frame of each animation
+    const animate = animations.map(name => {
+        const animation = artboard.animation(name);
+        const instance = new rive.LinearAnimationInstance(animation);
+        return (delta: number) => {
+            instance.advance(delta);
+            instance.apply(artboard, 1.0);
+        }
+    });
+
+    // Draw of the canvas
+    let lastTime = 0;
+    function draw(time: number) {
+        if (!lastTime) lastTime = time;
+    
+        const delta = (time - lastTime) / 1000;
+        lastTime = time;
+
+        animate.forEach(cb => cb(delta))
+        artboard.advance(delta);
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.save();
+        renderer.align(rive.Fit.contain, rive.Alignment.center, {
+            minX: 0,
+            minY: 0,
+            maxX: canvas.width,
+            maxY: canvas.height
+        }, artboard.bounds);
+        artboard.draw(renderer);
+        ctx.restore();
+        requestAnimationFrame(draw);
+    }
+
+    // Animation Frame run in the WebWorker
+    requestAnimationFrame(draw);
+});
+```
+
+The code above will be running in a new thread 🎉.


### PR DESCRIPTION
fix #14

## Description
This PR add support for running Rive inside a WebWorker. There are many advantages for running an Canvas animation inside a WebWorker, this [article](https://developers.google.com/web/updates/2018/08/offscreen-canvas) is a good resource for example.

## Content
- Remove dependency on `document` to make it work with `OffscreenCanvas`
- Use `DOMMatrix` instead of deprecated `SVGMatrix`
- Update Readme with example for WebWorker.

I put a full working example inside the Readme.md. I'm happy to move it elsewhere if you have a better place in mind 😊.
