### PR TITLE
Rive js types

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -20,5 +20,6 @@
   "license": "MIT",
   "files": [
     "src/rive.js"
-  ]
+  ],
+  "typings": "./rive.d.ts"
 }

--- a/js/src/rive.d.ts
+++ b/js/src/rive.d.ts
@@ -24,8 +24,11 @@ export declare class CanvasAlignment {
 type LoopType = 'oneShot' | 'loop' | 'pingPong';
 
 declare class LoopEvent {
+  /** Name of the animation which triggers the event */
   animationName: string;
+  /** Index of the type: 0 (oneShot), 1 (loop), 2 (pingPong)  */
   loopType: number;
+  /** Type of loop of the animation  */
   loopName: LoopType;
 }
 

--- a/js/src/rive.d.ts
+++ b/js/src/rive.d.ts
@@ -1,0 +1,88 @@
+type CanvasFit = 'cover' | 'contain' | 'fill' | 'fitWidth' | 'fitHeight' | 'none' | 'scaleDown';
+type CanvasAlignmentValue = 'center' | 'topLeft' | 'topCenter' | 'topRight' | 'centerLeft' | 'centerRight' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';
+
+export interface CanvasAlignmentOptions {
+  fit?: CanvasFit;
+  alignment?: CanvasAlignmentValue;
+  minX?: number;
+  minY?: number;
+  maxX?: number;
+  maxY?: number;
+}
+
+export declare class CanvasAlignment {
+  constructor(options: CanvasAlignmentOptions);
+  fit: CanvasFit;
+  alignment: CanvasAlignmentValue;
+  minX?: number;
+  minY?: number;
+  maxX?: number;
+  maxY?: number;
+}
+
+
+type LoopType = 'oneShot' | 'loop' | 'pingPong';
+
+declare class LoopEvent {
+  animationName: string;
+  loopType: number;
+  loopName: LoopType;
+}
+
+interface AnimationEvents {
+  load: string;
+  loaderror: string;
+  play: string;
+  pause: string;
+  stop: string;
+  playerror: string;
+  loop: LoopEvent;
+}
+
+interface RiveAnimationOptions {
+  /** uri foir a Rive file (.riv) */
+  src?: string;
+  /** ArrayBuffer containing Rive data */
+  buffer?: ArrayBuffer;
+  /** Name of the artboard to load. Fallback to the default one if not provided */
+  artboard?: string;
+  /** Name of the animations to run. Fallback to the default one if not provided */
+  animations?: string | string[];
+  /** Canvas on which to load the animation */
+  canvas: HTMLCanvasElement | OffscreenCanvas;
+  alignment?: CanvasAlignment;
+  /** Should then animation run when loaded */
+  autoplay?: boolean;
+  onload?(cb: (message: string) => void): void;
+  onloaderror?(cb: (error: string) => void): void;
+  onplay?(cb: (message: string) => void): void;
+  onpause?(cb: (message: string) => void): void;
+  onstop?(cb: (message: string) => void): void;
+  onplayerror?(cb: (error: string) => void): void;
+  onloop?(cb: (event: LoopEvent) => void): void;
+}
+
+
+export declare class RiveAnimation {
+  constructor(options: RiveAnimationOptions);
+  /** Starts/continues playback */
+  play(): void;
+  /** Pauses playback */
+  pause(): void;
+  /** Stops playback; this will restart the animation states to the first frame */
+  stop(): void;
+  /** Returns true if playback is playing */
+  isPlaying(): boolean;
+  /** Returns true if playback is paused */
+  isPaused(): boolean;
+  /** Returns true if playback is stopped */
+  isStopped(): boolean;
+  /* Returns the animation source/name */
+  source(): string;
+  /* Returns a list of the names of animations on the chosen artboard */
+  animationNames(): string[];
+
+  /** Listen on events from the Animation */
+  on<K extends keyof AnimationEvents>(event: K, cb: (event: AnimationEvents[K]) => void): RiveAnimation;
+}
+

--- a/js/src/rive.js
+++ b/js/src/rive.js
@@ -65,7 +65,7 @@ var Rive=function(){var e="undefined"!=typeof document&&document.currentScript?d
     * Loop event constructor
     */
     var LoopEvent = function ({animationName, loopValue}) {
-        if (loopValue < 0 || loopValue > loopTypes.length) {
+        if (loopValue < 0 || loopValue >= loopTypes.length) {
             console.error('Invalid loop value');
             return;
         }
@@ -150,7 +150,7 @@ var Rive=function(){var e="undefined"!=typeof document&&document.currentScript?d
     * RiveAnimation constructor
     */    
     var RiveAnimation = function({
-        src, // uri foir a Rive file (.riv)
+        src, // uri for a Rive file (.riv)
         buffer, // ArrayBuffer containing Rive data
         artboard,
         animations,


### PR DESCRIPTION
Add types for `rive-js`.
Update package.json accordingly
Fix small typo: 
`if (loopValue < 0 || loopValue > loopTypes.length)` should be `if (loopValue < 0 || loopValue >= loopTypes.length)`, else value 3 is a valid value.