### PR TITLE
publish types in rive-canvas again

### DIFF
--- a/wasm/publish/package.json
+++ b/wasm/publish/package.json
@@ -15,7 +15,8 @@
     "rive.min.js",
     "rive.pure.js",
     "rive.pure.min.js",
-    "rive.wasm"
+    "rive.wasm",
+    "types.d.ts"
   ],
   "keywords": [
     "rive",


### PR DESCRIPTION
Typescript throw compilations errors for `ng-rive` if types are not exported by `rive-wasm`.