### PR TITLE
Export StateMachineInput class

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -252,7 +252,7 @@ export enum StateMachineInputType {
 /**
  * An input for a state machine
  */
-class StateMachineInput {
+export class StateMachineInput {
 
   constructor(public readonly type: StateMachineInputType, private runtimeInput: rc.SMIInput) { }
 


### PR DESCRIPTION
The CommunityShot page gets all the stateMachineInputs to determine what to put in the inputs section, so it's super helpful to have this type as well!