### PR TITLE
Fixes unique version number check.

### DIFF
--- a/js/next_version.js
+++ b/js/next_version.js
@@ -18,7 +18,7 @@ for (let version of versions) {
     for (let i = 0; i < version.length; i++) {
         version[i] = Number.parseInt(version[i]);
     }
-    if (current[0] == version[0] && current[1] == version[1] && buildNumber < version[2]) {
+    if (current[0] == version[0] && current[1] == version[1] && buildNumber <= version[2]) {
         buildNumber = version[2] + 1;
     }
 


### PR DESCRIPTION
next_version.js would fail if there were versions like this in the list:
['0.7.15', '0.7.16']

It would find 0.7.15 and bump the target buildNumber to 16. Then when it compared 0.7.16 it would see that the build number wasn't less than the new one and proceed, keeping the target at 16.

This caused it to try to publish 0.7.16 again. Easy fix, needs a less than or equal :)