### PR TITLE
Fallback context to webgl if webgl2 not available

### DIFF
--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -14,7 +14,14 @@ Module.onRuntimeInitialized = function () {
             'explicitSwapControl': 0,
             'renderViaOffscreenBackBuffer': 0
         };
-        var handle = GL.createContext(canvas, contextAttributes);
+
+        var ctx = canvas.getContext('webgl2', contextAttributes);
+        // Fallback for browsers that don't support webgl2 (e.g Safari 14)
+        if (!ctx) {
+            ctx = canvas.getContext('webgl', contextAttributes);
+        }
+        var handle = GL.registerContext(ctx, contextAttributes);
+
         GL.makeContextCurrent(handle);
 
         const renderer = makeRenderer(canvas.width, canvas.height);

--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -90,7 +90,9 @@ filter "options:skia"
     libdirs {"submodules/rive-cpp/skia/dependencies/skia/out/wasm/"}
     links {"skia", "GL"}
     linkoptions {
-            "-s USE_WEBGL2=1", 
+            "-s USE_WEBGL2=1",
+            "-s MIN_WEBGL_VERSION=1",
+            "-s MAX_WEBGL_VERSION=2",
             "--pre-js ./js/skia_renderer.js"
         }
 


### PR DESCRIPTION
We no longer call `createContext`, as it's not doing what we want it to do. While there's some fixes for different browser versions within that function but I don't think there's anything major there we need to work. You can check for yourself here: https://github.com/emscripten-core/emscripten/blob/main/src/library_webgl.js#L575-L709