### PR TITLE
Fix lag when using context2d and add fps/frametime metrics to runtime

### DIFF
--- a/js/examples/hello_world/index.html
+++ b/js/examples/hello_world/index.html
@@ -11,7 +11,7 @@
             <canvas id="canvas" width="500" height="500"></canvas>
         </div>
 
-        <script src="/dist/rive.min.js"></script>
+        <script src="https://unpkg.com/@rive-app/webgl@latest"></script>
         <script>
             // autoplays the first animation in the default artboard
             new rive.Rive({

--- a/js/examples/hello_world/index.html
+++ b/js/examples/hello_world/index.html
@@ -11,7 +11,7 @@
             <canvas id="canvas" width="500" height="500"></canvas>
         </div>
 
-        <script src="https://unpkg.com/@rive-app/webgl@latest"></script>
+        <script src="/dist/rive.min.js"></script>
         <script>
             // autoplays the first animation in the default artboard
             new rive.Rive({

--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1255,7 +1255,6 @@ export class Rive {
     const {renderer, runtime, _layout, artboard} = this;
     // Canvas must be wiped to prevent artifacts
     renderer.clear();
-    // Now save so that future changes to align can restore
     // Align things up safe in the knowledge we can restore if changed
     renderer.align(
       _layout.runtimeFit(runtime),

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -52,7 +52,10 @@ const canvas = {
         }
       }
     })
-  ]
+  ],
+  watchOptions: {
+    ignored: ['**/node_modules', '**/npm'],
+  },
 };
 
 // Uses canvas_advanced with a bundled wasm file for simplicity/no external wasm
@@ -103,7 +106,10 @@ const canvasSingle = {
         }
       }
     })
-  ]
+  ],
+  watchOptions: {
+    ignored: ['**/node_modules', '**/npm'],
+  },
 };
 
 
@@ -155,7 +161,10 @@ const webgl = {
         }
       }
     })
-  ]
+  ],
+  watchOptions: {
+    ignored: ['**/node_modules', '**/npm'],
+  },
 };
 
 // Uses webgl_advanced with a bundled wasm file for simplicity/no external wasm
@@ -206,7 +215,10 @@ const webglSingle = {
         }
       }
     })
-  ]
+  ],
+  watchOptions: {
+    ignored: ['**/node_modules', '**/npm'],
+  },
 };
 
 module.exports = [canvasSingle, canvas, webglSingle, webgl];


### PR DESCRIPTION
* Removes an extra `renderer.save()`. This was causing the context stack grow which caused the eventual lag. You can replicate the lag easily by adding a couple of extra calls.
* Add an fps/frametime counter to the high level runtime. We might want to make this optional for performance reasons, however the overhead seems really small.
* Fixed some watch issues with webgl