### PR TITLE
Update rive-wasm to use skia_rive_optimized version of skia.

### DIFF
--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -81,13 +81,13 @@ filter "options:skia"
     defines {"RIVE_SKIA_RENDERER"}
     buildoptions { "-DSK_GL", "-DSK_SUPPORT_GPU=1" }
     includedirs {"./submodules/rive-cpp/skia/renderer/include", 
-                "./submodules/rive-cpp/skia/dependencies/skia", 
-                "./submodules/rive-cpp/skia/dependencies/skia/include/core",
-                "./submodules/rive-cpp/skia/dependencies/skia/include/effects", 
-                "./submodules/rive-cpp/skia/dependencies/skia/include/gpu",
-                "./submodules/rive-cpp/skia/dependencies/skia/include/config"}
+                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized", 
+                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/core",
+                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/effects", 
+                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/gpu",
+                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/config"}
     files {"./submodules/rive-cpp/skia/renderer/src/**.cpp"}
-    libdirs {"submodules/rive-cpp/skia/dependencies/skia/out/wasm/"}
+    libdirs {"submodules/rive-cpp/skia/dependencies/skia_rive_optimized/out/wasm/"}
     links {"skia", "GL"}
     linkoptions {
             "-s USE_WEBGL2=1",


### PR DESCRIPTION
Uses the latest version of rive-cpp which splits out "skia" and "skia_rive_optimized". This ensures that rive-wasm uses "skia_rive_optimized"