### PR TITLE
Feat: Add util function on rive object to set canvas drawing board size based on devicePixelRatio

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -845,11 +845,6 @@ export interface RiveParameters {
   onLoop?: EventCallback,
   onStateChange?: EventCallback,
   /**
-   * If true, the canvas will scale the drawing board size based on a multiplier of the devicePixelRatio. 
-   * Defaults to true.
-   */
-  useDevicePixelRatio?: boolean,
-  /**
    * @deprecated Use `onLoad()` instead
    */
   onload?: EventCallback,
@@ -952,9 +947,6 @@ export class Rive {
 
   // Animator: manages animations and state machines
   private animator: Animator;
-
-  // Tracks whether to use devicePixelRatio to determine canvas drawing size
-  private useDevicePixelRatio: boolean = true;
 
   // Error message for missing source or buffer
   private static readonly missingErrorMessage: string =
@@ -1439,14 +1431,9 @@ export class Rive {
   public resizeDrawingSurfaceToCanvas() {
     if (this.canvas instanceof HTMLCanvasElement && !!window) {
       const {width, height} = this.canvas.getBoundingClientRect();
-      if (this.useDevicePixelRatio) {
-        const dpr = window.devicePixelRatio || 1;
-        this.canvas.width = dpr * width;
-        this.canvas.height = dpr * height;
-      } else {
-        this.canvas.width = width;
-        this.canvas.height = height;
-      }
+      const dpr = window.devicePixelRatio || 1;
+      this.canvas.width = dpr * width;
+      this.canvas.height = dpr * height;
       this.startRendering();
       this.resizeToCanvas();
     }


### PR DESCRIPTION
We've received a few comments on why the initial render looks pixelated using the JS runtime. Perhaps instead of relying on consumers to set width/height attributes (usually the reason), we can set them based on the size of the canvas and `window.devicePixelRatio`. This seems to be similar to what the `rive-react` runtime is doing implicitly, but that runtime does a tad more style manipulating because it also controls a container div wrapping the canvas.

Consumers can use this API in a window resizing function to continuously scale the drawing board size of the canvas. If folks initially set a width/height attribute on the canvas, we don't initially run this util (so as not to break existing implementations).

Open to other thoughts here too