### PR TITLE
Feat: New useOffscreenRenderer param set in the high-level API constructor set at false by default

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -300,6 +300,21 @@ The following are more properties exposed on the Rive object during instantiatio
 - _isPaused_: are all animations paused?
 - _isStopped_: are all animation stopped?
 
+### Other Notes
+If you plan on using `@rive-app/webgl` for the high-level runtime and have a fair number of Rive animations displaying on the screen all at once, we recommend setting the `useOffscreenRenderer` parameter on intialization to `true` during instantiation. Read more about how the animations will share a single shared context in our [WASM docs](https://github.com/rive-app/rive-wasm/tree/master/wasm#gl-contexts) and see below for an example:
+
+```js
+const foo = new Rive({
+    src: "truck.riv",
+    canvas: canvasInstance,
+    animations: "idle",
+    layout: new Layout({fit: "cover", alignment: "center"}),
+    autoplay: true,
+    useOffscreenRenderer: true,
+});
+```
+Note that in a our next major version, this may be turned on by default.
+
 ## Examples
 
 To run the examples in the `examples` folder, run a HTTP server at the root of the `js` directory. If you have Python installed, the following works nicely:

--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -837,6 +837,7 @@ export interface RiveParameters {
   stateMachines?: string | string[],
   layout?: Layout,
   autoplay?: boolean,
+  useOffscreenRenderer?: boolean,
   onLoad?: EventCallback,
   onLoadError?: EventCallback,
   onPlay?: EventCallback,
@@ -882,6 +883,7 @@ export interface RiveLoadParameters {
   artboard?: string,
   animations?: string | string[],
   stateMachines?: string | string[],
+  useOffscreenRenderer?: boolean,
 }
 
 // Interface ot Rive.reset function
@@ -994,6 +996,7 @@ export class Rive {
       animations: params.animations,
       stateMachines: params.stateMachines,
       artboard: params.artboard,
+      useOffscreenRenderer: params.useOffscreenRenderer,
     });
   }
 
@@ -1004,7 +1007,7 @@ export class Rive {
   }
 
   // Initializes the Rive object either from constructor or load()
-  private init({ src, buffer, animations, stateMachines, artboard, autoplay = false }: RiveLoadParameters): void {
+  private init({ src, buffer, animations, stateMachines, artboard, autoplay = false, useOffscreenRenderer = false }: RiveLoadParameters): void {
     this.src = src;
     this.buffer = buffer;
 
@@ -1028,7 +1031,7 @@ export class Rive {
       this.runtime = runtime;
 
       // Get the canvas where you want to render the animation and create a renderer
-      this.renderer = this.runtime.makeRenderer(this.canvas);
+      this.renderer = this.runtime.makeRenderer(this.canvas, useOffscreenRenderer);
 
       // Initial size adjustment based on devicePixelRatio if no width/height are specified explicitly
       if (!(this.canvas.width || this.canvas.height)) {

--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -21,7 +21,7 @@ interface RiveOptions {
     StrokeJoin: typeof StrokeJoin;
   
     load(buffer: Uint8Array): File;
-    makeRenderer(canvas: HTMLCanvasElement | OffscreenCanvas) : CanvasRenderer;
+    makeRenderer(canvas: HTMLCanvasElement | OffscreenCanvas, useOffscreenRenderer: boolean) : CanvasRenderer;
   }
   
   //////////////


### PR DESCRIPTION
This adds high-level API support for using the shared WebGL context, introduced in: https://github.com/rive-app/rive-wasm/pull/188

It's set to false by default, so no breaking change here.