### PR TITLE
Initial work to make js/build.sh support incremental builds

### DIFF
--- a/wasm/build_all_wasm.sh
+++ b/wasm/build_all_wasm.sh
@@ -68,4 +68,4 @@ echo "::::: building @rive-app/webgl_advanced_single"
 echo 
 ./build_wasm.sh clean
 OUT_DIR=build/webgl_advanced_single ./build_wasm.sh -r skia -s release
-cp build/bin/release/webgl_advanced_single.mjs ../js/npm/webgl_advanced_single/webgl_advanced_single.mjs
+cp build/webgl_advanced_single/bin/release/webgl_advanced_single.mjs ../js/npm/webgl_advanced_single/webgl_advanced_single.mjs

--- a/wasm/build_all_wasm.sh
+++ b/wasm/build_all_wasm.sh
@@ -35,34 +35,37 @@ mkdir -p ../js/npm/webgl_advanced
 mkdir -p ../js/npm/canvas_advanced_single
 mkdir -p ../js/npm/webgl_advanced_single
 
+# Comment this block to use incremental builds.
+echo
+echo "::::: cleaning all projects"
+echo
+rm -fR ./build
+
 echo 
 echo "::::: building @rive-app/canvas_advanced"
 echo 
-./build_wasm.sh clean
-./build_wasm.sh release
-cp build/bin/release/canvas_advanced.mjs ../js/npm/canvas_advanced/canvas_advanced.mjs
-cp build/bin/release/canvas_advanced.wasm ../js/npm/canvas_advanced/rive.wasm
-cp build/bin/release/canvas_advanced.wasm ../js/npm/canvas/rive.wasm
+OUT_DIR=build/canvas_advanced ./build_wasm.sh release
+cp build/canvas_advanced/bin/release/canvas_advanced.mjs ../js/npm/canvas_advanced/canvas_advanced.mjs
+cp build/canvas_advanced/bin/release/canvas_advanced.wasm ../js/npm/canvas_advanced/rive.wasm
+cp build/canvas_advanced/bin/release/canvas_advanced.wasm ../js/npm/canvas/rive.wasm
 
 echo 
 echo "::::: building @rive-app/canvas_advanced_single"
 echo 
-./build_wasm.sh clean
-./build_wasm.sh -s release
-cp build/bin/release/canvas_advanced_single.mjs ../js/npm/canvas_advanced_single/canvas_advanced_single.mjs
+OUT_DIR=build/canvas_advanced_single ./build_wasm.sh -s release
+cp build/canvas_advanced_single/bin/release/canvas_advanced_single.mjs ../js/npm/canvas_advanced_single/canvas_advanced_single.mjs
 
 echo 
 echo "::::: building @rive-app/webgl_advanced"
 echo 
-./build_wasm.sh clean
-./build_wasm.sh -r skia release
-cp build/bin/release/webgl_advanced.mjs ../js/npm/webgl_advanced/webgl_advanced.mjs
-cp build/bin/release/webgl_advanced.wasm ../js/npm/webgl_advanced/rive.wasm
-cp build/bin/release/webgl_advanced.wasm ../js/npm/webgl/rive.wasm
+OUT_DIR=build/webgl_advanced ./build_wasm.sh -r skia release
+cp build/webgl_advanced/bin/release/webgl_advanced.mjs ../js/npm/webgl_advanced/webgl_advanced.mjs
+cp build/webgl_advanced/bin/release/webgl_advanced.wasm ../js/npm/webgl_advanced/rive.wasm
+cp build/webgl_advanced/bin/release/webgl_advanced.wasm ../js/npm/webgl/rive.wasm
 
 echo 
 echo "::::: building @rive-app/webgl_advanced_single"
 echo 
 ./build_wasm.sh clean
-./build_wasm.sh -r skia -s release
+OUT_DIR=build/webgl_advanced_single ./build_wasm.sh -r skia -s release
 cp build/bin/release/webgl_advanced_single.mjs ../js/npm/webgl_advanced_single/webgl_advanced_single.mjs

--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -5,8 +5,8 @@ project "rive"
 kind "ConsoleApp"
 language "C++"
 cppdialect "C++17"
-targetdir "build/bin/%{cfg.buildcfg}"
-objdir "build/obj/%{cfg.buildcfg}"
+targetdir ((os.getenv("OUT_DIR") or "build") .. "/bin/%{cfg.buildcfg}")
+objdir ((os.getenv("OUT_DIR") or "build") .. "/obj/%{cfg.buildcfg}")
 includedirs {"./submodules/rive-cpp/include"}
 
 files {"./submodules/rive-cpp/src/**.cpp", "./src/bindings.cpp"}
@@ -57,24 +57,24 @@ linkoptions {
 filter { "options:not skia", "options:not single_file" }
     linkoptions {
             "--pre-js ./js/renderer.js",
-            "-o build/bin/%{cfg.buildcfg}/canvas_advanced.mjs",
+            "-o %{cfg.targetdir}/canvas_advanced.mjs",
         }
 
 filter { "options:not skia", "options:single_file" }
     linkoptions {
             "--pre-js ./js/renderer.js",
-            "-o build/bin/%{cfg.buildcfg}/canvas_advanced_single.mjs",
+            "-o %{cfg.targetdir}/canvas_advanced_single.mjs",
         }
 
 
 filter { "options:skia", "options:single_file" }
     linkoptions {
-        "-o build/bin/%{cfg.buildcfg}/webgl_advanced_single.mjs",
+        "-o %{cfg.targetdir}/webgl_advanced_single.mjs",
     }
 
 filter { "options:skia", "options:not single_file" }
     linkoptions {
-        "-o build/bin/%{cfg.buildcfg}/webgl_advanced.mjs",
+        "-o %{cfg.targetdir}/webgl_advanced.mjs",
     }
 
 filter "options:skia"


### PR DESCRIPTION
Builds the various targets in their own directories. Moves the "clean"
step to a block that can be commented out in order to enable incremental
builds. Build steps for individual targets can also be commented out now
that their artifacts persist if we skip the clean step.