### PR TITLE
Fix alignment issues caused by clearing inside of a save/restore.

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1213,6 +1213,8 @@ export class Rive {
     this.artboard.advance(elapsedTime);
 
     const {renderer} = this;
+    // Canvas must be wiped to prevent artifacts
+    renderer.clear();
     renderer.save();
 
     // Update the renderer alignment if necessary
@@ -1261,8 +1263,6 @@ export class Rive {
    */
   private alignRenderer(): void {
     const {renderer, runtime, _layout, artboard} = this;
-    // Canvas must be wiped to prevent artifacts
-    renderer.clear();
     // Align things up safe in the knowledge we can restore if changed
     renderer.align(
       _layout.runtimeFit(runtime),


### PR DESCRIPTION
Fixes the alignment issue we've been seeing in Rive-React.

Issue was caused by calling renderer.clear() inside of a save()/restore(). The clear op could recreate the surface (which blows aways the canvas context) so then you'll end up with an extra align always on the stack.