### PR TITLE
Don't allocate a depth buffer for the WebGL renderer

### DIFF
--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -48,7 +48,7 @@ Module.onRuntimeInitialized = function () {
     function makeGLRenderer(canvas) {
         var contextAttributes = {
             'alpha': 1,
-            'depth': 1,
+            'depth': 0,
             'stencil': 8,
             'antialias': 1,
             'premultipliedAlpha': 1,


### PR DESCRIPTION
Save the memory -- Skia doesn't use a depth buffer.