### PR TITLE
Fix: Make canvas and animation order deterministic and don't use offscreen renderer in FF

### DIFF
--- a/wasm/examples/parcel_example/index.js
+++ b/wasm/examples/parcel_example/index.js
@@ -62,6 +62,7 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
   }
   canvas.width = hasRandomSizes ? `${randomNum}` : "400";
   canvas.height = hasRandomSizes ? `${randomNum}` : "400";
+  // Don't use the offscreen renderer for FF as it should have a context limit of 300
   const renderer = rive.makeRenderer(canvas, !isFF);
 
   function loadFile(droppedFile) {

--- a/wasm/examples/parcel_example/index.js
+++ b/wasm/examples/parcel_example/index.js
@@ -28,6 +28,8 @@ const RIVE_EXAMPLES = {
   },
 };
 
+const isFF = navigator.userAgent.match(/firefox|fxios/i);
+
 // Loads a default animation and displays it using the advanced api. Drag and
 // drop .riv files to see them and play their default animations.
 async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
@@ -60,7 +62,7 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
   }
   canvas.width = hasRandomSizes ? `${randomNum}` : "400";
   canvas.height = hasRandomSizes ? `${randomNum}` : "400";
-  const renderer = rive.makeRenderer(canvas, true);
+  const renderer = rive.makeRenderer(canvas, !isFF);
 
   function loadFile(droppedFile) {
     const reader = new FileReader();
@@ -170,7 +172,7 @@ async function main() {
   const hasRandomSizes = !!params.hasRandomSizes || false;
   const rive = await RiveCanvas();
   for (let i = 0; i < numCanvases; i++) {
-    renderRiveAnimation({ rive, num: i, hasRandomSizes });
+    await renderRiveAnimation({ rive, num: i, hasRandomSizes });
   }
 }
 


### PR DESCRIPTION
Fixing a small bug in the parcel example. Also a request to test out no offscreen renderer in firefox as a few of us are able to repro a 300 webgl context limit.