### PR TITLE
Add rive.requestAnimationFrame

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1629,7 +1629,11 @@ export class Rive {
    */
   public startRendering() {
     if (this.loaded && !this.frameRequestId) {
-      this.frameRequestId = requestAnimationFrame(this.draw.bind(this));
+      if (this.runtime.requestAnimationFrame) {
+        this.frameRequestId = this.runtime.requestAnimationFrame(this.draw.bind(this));
+      } else {
+        this.frameRequestId = requestAnimationFrame(this.draw.bind(this));
+      }
     }
   }
 

--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -22,6 +22,7 @@ interface RiveOptions {
   
     load(buffer: Uint8Array): File;
     makeRenderer(canvas: HTMLCanvasElement | OffscreenCanvas, useOffscreenRenderer: boolean) : CanvasRenderer;
+    requestAnimationFrame(cb: (timestamp: DOMHighResTimeStamp) => void): number;
   }
   
   //////////////

--- a/wasm/examples/parcel_example/index.js
+++ b/wasm/examples/parcel_example/index.js
@@ -160,9 +160,9 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
       durations.reduce((p, n) => p + n, 0) / durations.length
     ).toFixed(4);
 
-    requestAnimationFrame(draw);
+    rive.requestAnimationFrame(draw);
   }
-  requestAnimationFrame(draw);
+  rive.requestAnimationFrame(draw);
 }
 
 async function main() {

--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -292,4 +292,7 @@ Rive.onRuntimeInitialized = function () {
             return new CanvasRenderImage();
         }
     };
+
+
+    Rive['requestAnimationFrame'] = window['requestAnimationFrame'].bind(window);
 };

--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -106,4 +106,6 @@ Module.onRuntimeInitialized = function () {
         }
         cppClear.call(this);
     };
+
+    Module['requestAnimationFrame'] = window['requestAnimationFrame'].bind(window);
 };


### PR DESCRIPTION
This will allow us to defer offscreen canvas renderings until they can
all be batched together in a single atlas.