### PR TITLE
Optimize MaxRecentSize

### DIFF
--- a/wasm/js/max_recent_size.js
+++ b/wasm/js/max_recent_size.js
@@ -1,25 +1,29 @@
 // Tracks the max size that has been pushed within a given window of time.
 // Used as a buffer to avoid thrashing allocations of GL buffers.
-function MaxRecentSize(milliseconds) {
+// All values are rounded up to the next multiple of 2^bitShift.
+function MaxRecentSize(milliseconds, bitShift) {
     console.assert(milliseconds > 0);
     const _map = new Map();
-    const _getMax = function(now) {
-        // Return the max size in our window.
-        let maxSize = 0;
-        _map.forEach((expiration, size) => {
-            if (now > expiration) {
-                _map.delete(size);
-            } else {
-                maxSize = Math.max(maxSize, size);
-            }
-        });
-        return maxSize;
-    };
+    let _maxSize = -Infinity;
     this.push = function(size) {
-        const now = Date.now();
-        const expiration = now + milliseconds;
-        // Set (or update) the expiration time for this size before calling _getMax().
-        _map.set(size, expiration);
-        return _getMax(now);
+        // Store values in right-shifted form. We will shift left before returning back to the user.
+        // Also add 2^(bitShift - 1) before shifting, to ensure we only round upward.
+        size = (size + ((1 << bitShift) - 1)) >> bitShift;
+        // Erase the previous eviction timer for the value 'size', if any.
+        if (_map.has(size)) {
+            clearTimeout(_map.get(size));
+        }
+        // Set an eviction timer for the value 'size'.
+        _map.set(size, setTimeout(function() {
+            _map.delete(size);
+            if (_map.length == 0) {
+                _maxSize = -Infinity;
+            } else if (size == _maxSize) {
+                _maxSize = Math.max(..._map.keys());
+                console.assert(_maxSize < size);
+            }
+        }, milliseconds));
+        _maxSize = Math.max(size, _maxSize);
+        return _maxSize << bitShift;
     };
 }

--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -108,10 +108,10 @@ const offscreenWebGL = new (function() {
         return texture;
     }
 
-    const _maxRecentWidth = new MaxRecentSize(1000/*ms*/);
-    const _maxRecentHeight = new MaxRecentSize(1000/*ms*/);
-    const _maxRecentVertexCount = new MaxRecentSize(1000/*ms*/);
-    const _maxRecentIndexCount = new MaxRecentSize(1000/*ms*/);
+    const _maxRecentWidth = new MaxRecentSize(1000/*ms*/, 8/*aligned to multiples of 256*/);
+    const _maxRecentHeight = new MaxRecentSize(1000/*ms*/, 8/*aligned to multiples of 256*/);
+    const _maxRecentVertexCount = new MaxRecentSize(1000/*ms*/, 10/*aligned to multiples of 1024*/);
+    const _maxRecentIndexCount = new MaxRecentSize(1000/*ms*/, 10/*aligned to multiples of 1024*/);
 
     this.drawImageMesh = function(ctx, imageTexture, canvasBlend, opacity, vertices, uv, indices) {
         if (!initGL()) {

--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -122,15 +122,8 @@ Module.onRuntimeInitialized = function () {
     function nextlog2(n) { return n <= 0 ? 0 : 32 - Math.clz32(n - 1); }
     function nextpow2(n) { return 1 << nextlog2(n); }
 
-    // Rounds n to the next multiple of pow2.
-    function alignUp(n, pow2) {
-        const mask = pow2 - 1;
-        console.assert((pow2 & mask) == 0);  // Verify that pow2 is indeed a power of 2.
-        return (n + mask) & ~mask;
-    }
-
-    const _atlasMaxRecentWidth = new MaxRecentSize(1000 /*1 second*/);
-    const _atlasMaxRecentHeight = new MaxRecentSize(1000 /*1 second*/);
+    const _atlasMaxRecentWidth = new MaxRecentSize(1000/*1sec*/, 8/*aligned to multiples of 256*/);
+    const _atlasMaxRecentHeight = new MaxRecentSize(1000/*1sec*/, 8/*aligned to multiples of 256*/);
 
     // Draws the offscreen renderers all together in a single atlas.
     function flushOffscreenRenderers() {
@@ -198,10 +191,8 @@ Module.onRuntimeInitialized = function () {
             //   * or the largest atlas dimensions we have used over the past second.
             //
             // Take whichever of those is larger and round it up to the nearest multiple of 512.
-            const atlasWidth = alignUp(_atlasMaxRecentWidth.push(rectanizer['drawWidth']()),
-                                       Math.min(512, maxRTSize));
-            const atlasHeight = alignUp(_atlasMaxRecentHeight.push(rectanizer['drawHeight']()),
-                                        Math.min(512, maxRTSize));
+            const atlasWidth = _atlasMaxRecentWidth.push(rectanizer['drawWidth']());
+            const atlasHeight = _atlasMaxRecentHeight.push(rectanizer['drawHeight']());
             console.assert(atlasWidth >= rectanizer['drawWidth']());
             console.assert(atlasHeight >= rectanizer['drawHeight']());
             console.assert(atlasWidth <= maxRTSize);


### PR DESCRIPTION
* Rely on timeouts to evict items, rather than polling.
* Round entries up to multiples of 2^n, in order to reduce the size of
  the map.
* Unfortunately we don't have a sorted map in Javascript. Otherwise the
  time to find the next max value (after evicting the current max) could
  be log N.