### PR TITLE
Add an fps counter to AnimationCallbackHandler

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1654,6 +1654,7 @@ export class Rive {
 
   /**
    * Enables frames-per-second (FPS) reporting for the runtime
+   * If no callback is provided, Rive will append a fixed-position div at the top-right corner of the page with the FPS reading
    * @param fpsCallback - Callback from the runtime during the RAF loop that supplies the FPS value
    */
   public enableFPSCounter(fpsCallback?: FPSCallback) {

--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -734,6 +734,11 @@ export interface EventListener {
   callback: EventCallback,
 }
 
+/**
+ * FPS Reporting through callbacks sent to the WASM runtime
+ */
+export type FPSCallback = (fps: number) => void;
+
 // Manages Rive events and listeners
 class EventManager {
 
@@ -1645,6 +1650,21 @@ export class Rive {
         this.frameRequestId = requestAnimationFrame(this.draw.bind(this));
       }
     }
+  }
+
+  /**
+   * Enables frames-per-second (FPS) reporting for the runtime
+   * @param fpsCallback - Callback from the runtime during the RAF loop that supplies the FPS value
+   */
+  public enableFPSCounter(fpsCallback?: FPSCallback) {
+    this.runtime.enableFPSCounter(fpsCallback);
+  }
+
+  /**
+   * Disables frames-per-second (FPS) reporting for the runtime
+   */
+  public disableFPSCounter() {
+    this.runtime.disableFPSCounter();
   }
 
   /**

--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -24,6 +24,8 @@ interface RiveOptions {
     makeRenderer(canvas: HTMLCanvasElement | OffscreenCanvas, useOffscreenRenderer: boolean) : CanvasRenderer;
     requestAnimationFrame(cb: (timestamp: DOMHighResTimeStamp) => void): number;
     cancelAnimationFrame(requestID: number): void;
+    enableFPSCounter(cb: (fps: number) => void): void;
+    disableFPSCounter(): void;
   }
   
   //////////////

--- a/wasm/examples/parcel_example/index.html
+++ b/wasm/examples/parcel_example/index.html
@@ -1,10 +1,6 @@
 <!DOCTYPE html>
 <html>
   <body>
-    <div class="counter">
-      <div class="fps">fps: <span id="fps-value"></span></div>
-      <div class="framems">frame time ms: <span id="framems-value"></span></div>
-    </div>
     <canvas id="canvas0"></canvas>
     <script src="./index.js"></script>
   </body>

--- a/wasm/examples/parcel_example/index.js
+++ b/wasm/examples/parcel_example/index.js
@@ -100,9 +100,6 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
   let lastTime = 0;
   let artboard, stateMachine, animation;
 
-  const times = [];
-  const durations = [];
-
   function draw(time) {
     if (!lastTime) {
       lastTime = time;
@@ -110,15 +107,6 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
     const elapsedMs = time - lastTime;
     const elapsedSeconds = elapsedMs / 1000;
     lastTime = time;
-
-    const before = performance.now();
-    // Update fps
-    while (times.length > 0 && times[0] <= time - 1000) {
-      times.shift();
-      durations.shift();
-    }
-    times.push(before);
-    document.getElementById("fps-value").innerText = times.length;
 
     renderer.clear();
     if (artboard) {
@@ -147,14 +135,6 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
     }
     renderer.flush();
 
-    // Update frame time
-    const after = performance.now();
-    durations.push(after - before);
-    // Use average of all recent durations
-    document.getElementById("framems-value").innerText = (
-      durations.reduce((p, n) => p + n, 0) / durations.length
-    ).toFixed(4);
-
     rive.requestAnimationFrame(draw);
   }
   rive.requestAnimationFrame(draw);
@@ -167,6 +147,7 @@ async function main() {
   const numCanvases = parseInt(params.numCanvases || 0) || 19;
   const hasRandomSizes = !!params.hasRandomSizes || false;
   const rive = await RiveCanvas();
+  rive.enableFPSCounter();
   for (let i = 0; i < numCanvases; i++) {
     await renderRiveAnimation({ rive, num: i, hasRandomSizes });
   }

--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -719,5 +719,6 @@ Rive.onRuntimeInitialized = function () {
             _animationCallbackHandler.cancelAnimationFrame.bind(_animationCallbackHandler);
     Rive['enableFPSCounter'] =
             _animationCallbackHandler.enableFPSCounter.bind(_animationCallbackHandler);
+    Rive['disableFPSCounter'] = _animationCallbackHandler.disableFPSCounter;
     _animationCallbackHandler.onAfterCallbacks = flushCanvasRenderers;
 };

--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -717,5 +717,7 @@ Rive.onRuntimeInitialized = function () {
             _animationCallbackHandler.requestAnimationFrame.bind(_animationCallbackHandler);
     Rive['cancelAnimationFrame'] =
             _animationCallbackHandler.cancelAnimationFrame.bind(_animationCallbackHandler);
+    Rive['enableFPSCounter'] =
+            _animationCallbackHandler.enableFPSCounter.bind(_animationCallbackHandler);
     _animationCallbackHandler.onAfterCallbacks = flushCanvasRenderers;
 };

--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -259,6 +259,8 @@ Module.onRuntimeInitialized = function () {
             _animationCallbackHandler.requestAnimationFrame.bind(_animationCallbackHandler);
     Rive['cancelAnimationFrame'] =
             _animationCallbackHandler.cancelAnimationFrame.bind(_animationCallbackHandler);
+    Rive['enableFPSCounter'] =
+            _animationCallbackHandler.enableFPSCounter.bind(_animationCallbackHandler);
     _animationCallbackHandler.onAfterCallbacks = flushOffscreenRenderers;
 
     const cppClear = Module['WebGLRenderer']['prototype']['clear'];


### PR DESCRIPTION
This is a simple timer, fixed to the top right corner, that just
measures the speed of our global rive.requestAnimationFrame() callbacks.
It is enabled by calling rive.enableFPSCounter(true).