### PR TITLE
Fix: Don't flush offscreen renderers if there are none

### DIFF
--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -127,6 +127,9 @@ Module.onRuntimeInitialized = function () {
 
     // Draws the offscreen renderers all together in a single atlas.
     function flushOffscreenRenderers() {
+        if (!_offscreenGL) {
+            return;
+        }
         const maxRTSize = _offscreenGL._maxRTSize;
 
         // Gather some atlas stats and transfer the pending renders to a sortable array.
@@ -261,9 +264,7 @@ Module.onRuntimeInitialized = function () {
             _animationCallbackHandler.cancelAnimationFrame.bind(_animationCallbackHandler);
     Rive['enableFPSCounter'] =
             _animationCallbackHandler.enableFPSCounter.bind(_animationCallbackHandler);
-    if (_offscreenGL) {
-        _animationCallbackHandler.onAfterCallbacks = flushOffscreenRenderers;
-    }
+    _animationCallbackHandler.onAfterCallbacks = flushOffscreenRenderers;
 
     const cppClear = Module['WebGLRenderer']['prototype']['clear'];
     Module['WebGLRenderer']['prototype']['clear'] = function () {

--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -261,7 +261,9 @@ Module.onRuntimeInitialized = function () {
             _animationCallbackHandler.cancelAnimationFrame.bind(_animationCallbackHandler);
     Rive['enableFPSCounter'] =
             _animationCallbackHandler.enableFPSCounter.bind(_animationCallbackHandler);
-    _animationCallbackHandler.onAfterCallbacks = flushOffscreenRenderers;
+    if (_offscreenGL) {
+        _animationCallbackHandler.onAfterCallbacks = flushOffscreenRenderers;
+    }
 
     const cppClear = Module['WebGLRenderer']['prototype']['clear'];
     Module['WebGLRenderer']['prototype']['clear'] = function () {


### PR DESCRIPTION
For WebGL, if a user does not set `useOffscreenRenderer: true` as part of the attributes in instantiating Rive, they'll get a constant stream of errors due to a null reference in the `flushoffscreenRenderers` which is called in the render loop.

So doing a quick check here in the skia renderer