### PR TITLE
Change Artboard.js to always be an instance

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1120,8 +1120,7 @@ export class Rive {
       return;
     }
 
-    // Instance the artboard
-    this.artboard = rootArtboard.instance();
+    this.artboard = rootArtboard;
 
     // Check that the artboard has at least 1 animation
     if (this.artboard.animationCount() < 1) {

--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -99,15 +99,16 @@ interface RiveOptions {
   // File //
   //////////
   export declare class File {
-    defaultArtboard(): Artboard;
-    artboardByName(name: string): Artboard;
-    artboardByIndex(index: number): Artboard;
+    defaultArtboard(): Artboard;              // rive::ArtboardInstance
+    artboardByName(name: string): Artboard;   // rive::ArtboardInstance
+    artboardByIndex(index: number): Artboard; // rive::ArtboardInstance
     artboardCount(): number;
   }
+
+  // This wraps rive::ArtboardInstance*
   export declare class Artboard {
     get name(): string;
     get bounds(): AABB;
-    instance(): Artboard;
     // Deletes the backing wasm artboard instance
     delete(): void;
     advance(sec: number): any;

--- a/wasm/src/bindings.cpp
+++ b/wasm/src/bindings.cpp
@@ -674,16 +674,20 @@ EMSCRIPTEN_BINDINGS(RiveWASM) {
   class_<rive::File>("File")
       .function(
           "defaultArtboard",
-          select_overload<rive::Artboard *() const>(&rive::File::artboard),
+          optional_override([](rive::File& self) -> rive::Artboard* {
+            return self.artboardAt(0).release();
+          }),
           allow_raw_pointers())
       .function("artboardByName",
-                select_overload<rive::Artboard *(std::string) const>(
-                    &rive::File::artboard),
-                allow_raw_pointers())
+          optional_override([](rive::File& self, std::string name) -> rive::Artboard* {
+            return self.artboardNamed(name).release();
+          }),
+          allow_raw_pointers())
       .function("artboardByIndex",
-                select_overload<rive::Artboard *(size_t) const>(
-                    &rive::File::artboard),
-                allow_raw_pointers())
+          optional_override([](rive::File& self, size_t index) -> rive::Artboard* {
+            return self.artboardAt(index).release();
+          }),
+          allow_raw_pointers())
       .function("artboardCount", &rive::File::artboardCount);
 
   class_<rive::Artboard>("Artboard")


### PR DESCRIPTION
Just changed the bindings to return the instance, and removed the "instance()" method from js

Lots of other "upgrades" to follow, but taking small steps...