### PR TITLE
bump submodule check to v8

### DIFF
--- a/.github/workflows/submodule_check.yaml
+++ b/.github/workflows/submodule_check.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run cpp version check
-        uses: rive-app/github-actions-submodule-check@v7
+        uses: rive-app/github-actions-submodule-check@v8
         with:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SUBMODULE_GIT_URL: https://github.com/rive-app/rive-cpp.git


### PR DESCRIPTION
updates our alerting around out of date submodules to show how many commits behind we are 
