### PR TITLE
Wait for all images to decode before completing load.

### DIFF
--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -20,7 +20,7 @@ interface RiveOptions {
     StrokeCap: typeof StrokeCap;
     StrokeJoin: typeof StrokeJoin;
   
-    load(buffer: Uint8Array): File;
+    load(buffer: Uint8Array): Promise<File>;
     makeRenderer(canvas: HTMLCanvasElement | OffscreenCanvas, useOffscreenRenderer: boolean) : CanvasRenderer;
     computeAlignment(fit: Fit, alignment: Alignment, frame: AABB, content: AABB): Mat2D;
     mapXY(matrix: Mat2D, canvasPoints: Vec2D): Vec2D;

--- a/js/test/rive.test.ts
+++ b/js/test/rive.test.ts
@@ -1041,8 +1041,8 @@ test('Artboards can be reset back to their starting state', done => {
 // #endregion
 
 test('Statemachines have pointer events', done => {
-  rive.RuntimeLoader.awaitInstance().then((runtime) => {
-    const file = runtime.load(new Uint8Array(stateMachineFileBuffer));
+  rive.RuntimeLoader.awaitInstance().then(async (runtime) => {
+    const file = await runtime.load(new Uint8Array(stateMachineFileBuffer));
     const ab = file.artboardByIndex(0);
     const sm = ab.stateMachineByIndex(0);
     const smi = new runtime.StateMachineInstance(sm, ab);

--- a/wasm/examples/parcel_example/index.js
+++ b/wasm/examples/parcel_example/index.js
@@ -50,7 +50,7 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
     const bytes = await (
       await fetch(new Request(riveEx.riveFile))
     ).arrayBuffer();
-    const file = rive.load(new Uint8Array(bytes));
+    const file = await rive.load(new Uint8Array(bytes));
     artboard = file.defaultArtboard();
     if (hasStateMachine) {
       stateMachine = new rive.StateMachineInstance(

--- a/wasm/js/skia_renderer.js
+++ b/wasm/js/skia_renderer.js
@@ -261,6 +261,11 @@ Module.onRuntimeInitialized = function () {
             _animationCallbackHandler.enableFPSCounter.bind(_animationCallbackHandler);
     _animationCallbackHandler.onAfterCallbacks = flushOffscreenRenderers;
 
+    let load = Rive["load"];
+    Rive["load"] = function (bytes) {
+      return Promise.resolve(load(bytes));
+    };
+    
     const cppClear = Module['WebGLRenderer']['prototype']['clear'];
     Module['WebGLRenderer']['prototype']['clear'] = function () {
         // Resize Skia surface if the canvas size changed.


### PR DESCRIPTION
I changed load to be async. This is a little funky as I basically replace the native bound "load" with a js one (we were doing this elsewhere for other functions) that returns a Promise.

With the Skia renderer this just returns an already resolved Promise as everything happens synchronously. 

With the Context2D/Canvas renderer we build a "loadContext" that synchronously gets accessed and stored in the load closures for each image. It's hacky but works with multiple loads. I did it this way to not patch anything at the C++ layer.

No breaking changes for the high level API. Small breaking change for the advanced API: they'll now need to await/.then the Promise returned from load.

P.S. formatting is messy, I'll separately PR with a formatter for JS with a note about it in the README.