### PR TITLE
Fix: Cleanup render loop and instances on Rive cleanup() and set artboard to null

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1454,8 +1454,16 @@ export class Rive {
     if (this.eventCleanup !== null) {
       this.eventCleanup();
     }
-    this.artboard.delete();
-    // TODO: delete animation and state machine instances
+    // Stop rAF loop if still continuing, and delete all animation and state machine
+    // instances
+    if (this.frameRequestId) {
+      this.stopRendering();
+      this.stop();
+    }
+    if (this.artboard) {
+      this.artboard.delete();
+      this.artboard = null;
+    }
   }
 
   // Plays specified animations; if none specified, it unpauses everything.
@@ -1614,7 +1622,7 @@ export class Rive {
    * Returns the name of the active artboard
    */
   public get activeArtboard(): string {
-    return this.artboard.name;
+    return this.artboard ? this.artboard.name : "";
   }
 
   // Returns a list of animation names on the chosen artboard

--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1454,12 +1454,8 @@ export class Rive {
     if (this.eventCleanup !== null) {
       this.eventCleanup();
     }
-    // Stop rAF loop if still continuing, and delete all animation and state machine
-    // instances
-    if (this.frameRequestId) {
-      this.stopRendering();
-      this.stop();
-    }
+    // Delete all animation and state machine instances
+    this.stop();
     if (this.artboard) {
       this.artboard.delete();
       this.artboard = null;
@@ -1541,7 +1537,6 @@ export class Rive {
     const autoplay = params?.autoplay ?? false;
 
     // Stop everything and clean up
-    this.stop();
     this.cleanup();
 
     // Reinitialize an artboard instance with the state
@@ -1802,7 +1797,7 @@ export class Rive {
    * renderer is already active, then this will have zero effect.
    */
   public startRendering() {
-    if (this.loaded && !this.frameRequestId) {
+    if (this.loaded && this.artboard && !this.frameRequestId) {
       if (this.runtime.requestAnimationFrame) {
         this.frameRequestId = this.runtime.requestAnimationFrame(
           this.draw.bind(this)

--- a/js/test/rive.test.ts
+++ b/js/test/rive.test.ts
@@ -1142,3 +1142,23 @@ test('Statemachines have pointer events', (done) => {
     done();
   });
 });
+
+// #region cleanup
+
+test('Rive deletes instances on the cleanup', (done) => {
+  const canvas = document.createElement('canvas');
+  const r = new rive.Rive({
+    canvas: canvas,
+    buffer: stateMachineFileBuffer,
+    autoplay: true,
+    artboard: 'MyArtboard',
+    onLoad: () => {
+      expect(r.activeArtboard).toBe('MyArtboard');
+      r.cleanup();
+      expect(r.activeArtboard).toBe('');
+      done();
+    },
+  });
+});
+
+// #endregion


### PR DESCRIPTION
Want to set artboard to null after cleanup so any lingering public methods that try and read from artboard don't try and access artboard pointer methods. Also adding `stop()` to cleanup, to properly clean up animation/state machine instances. That way, folks don't have to call `rive.stop()` and `rive.cleanup()` for a true cleanup.