### PR TITLE
Remove node from emscripten target environments

### DIFF
--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -44,6 +44,7 @@ linkoptions {
             -- "-s EXPORT_ES6=1",
             "-s USE_ES6_IMPORT_META=0", 
             "-s EXPORT_NAME=\"Rive\"", 
+            "-s ENVIRONMENT=\"web,webview,worker\"",
             "-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0", 
             "-DSINGLE",
             "-DANSI_DECLARATORS", 


### PR DESCRIPTION
By default, emscripten targets web, webview, worker and node (https://github.com/emscripten-core/emscripten/blob/6d3e1a9be15bc9ffbeb7f6ec81942bfef96336ad/src/settings.js#L615-L640). By targeting node, emscripten tries to pull in the process, fs and path dependencies if running on a node environment. jspm, which is the package CDN used by framer, automatically adds browser polyfills for these, which fail when framer tries to statically generate sites with rive files.

This config changes remove the node target, which fixes the above problem.