### PR TITLE
patch: Add dynamic execution flag to emcc build to allow for wasm-unsafe-eval in csp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v11
         with:
-          version: 3.0.0
+          version: 3.1.20
           actions-cache-folder: "emsdk-cache"
       - name: Install premake
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git checkout origin/master
 cd ../../..
 ```
 
-4. Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html). We build against 3.0.0 in rive-wasm
+4. Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html). We build against 3.1.20 in rive-wasm
 5. Install [Premake5](https://premake.github.io/) and add it to your path
 
 6. `cd` back into the `js` folder and run `./build.sh` from your terminal/shell to build the latest WASM and builds for JS API's (high and low level) into the `npm/` folder. This may take some time, grab a coffee! This should finish with Webpack building the JS bundles for the high-level API packages (more on that below)

--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -38,6 +38,7 @@ linkoptions {
             "-s NO_EXIT_RUNTIME=1", 
             "-s STRICT=1", 
             "-flto",
+            "-s DYNAMIC_EXECUTION=0",
             "-s ALLOW_MEMORY_GROWTH=1", 
             "-s DISABLE_EXCEPTION_CATCHING=1", 
             "-s WASM=1", 


### PR DESCRIPTION
Should help address https://github.com/rive-app/rive-wasm/issues/131

If folks set CSP policies that block `unsafe-eval` scripts (i.e use of `new Function()` or `eval()`), they may have issues rendering Rives because our WASM (built using Emscripten) that has binding code to JS includes some `new Function()` code as part of Emscripten's inner-workings around binding. There's [some effort](https://github.com/emscripten-core/emscripten/pull/17296) on Emscripten's side to remove some of these pieces, but the guidance for consumers as seen in [this issue](https://github.com/WebAssembly/content-security-policy/issues/7) is to allow `wasm-unsafe-eval` in the CSP. This alone however still doesn't solve everything. We need to set this `DYNAMIC_EXECUTION=0` flag to prevent the use of `new Function()` or `eval()` in Emscripten's native binding code during build. The pairing of this fix in our WASM build setup, and the consumer setting `wasm-unsafe-eval` should get Rives running in web apps if it were blocked before. While not perfect, it's better than setting `unsafe-eval` for sure as a content policy. 


If this takes, we'll document this in our JS runtimes gitbook section