### PR TITLE
patch: update publish script to use new emscripten version too

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v11
         with:
-          version: 3.0.0
+          version: 3.1.20
           actions-cache-folder: "emsdk-cache"
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Updated the build script here: https://github.com/rive-app/rive-wasm/pull/263 to use the new emsdk version, but forgot to update the `publish.yml` workflow too to use the new version.