### PR TITLE
Fix Alignment leak!

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,73 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+TabWidth: 4
+BreakBeforeBraces: Allman
+IndentCaseLabels: true
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+NamespaceIndentation: None
+AccessModifierOffset: -4
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ColumnLimit: 100
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: Align
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortCaseLabelsOnASingleLine: false
+PenaltyReturnTypeOnItsOwnLine: 100
+BreakBeforeBraces: Custom
+SortIncludes: false
+BraceWrapping:
+  AfterEnum: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterNamespace: true
+  AfterFunction: true
+  AfterStruct: true
+  AfterObjCDeclaration: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  AfterCaseLabel: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+---
+Language: ObjC
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+NamespaceIndentation: All
+AccessModifierOffset: -4
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ColumnLimit: 100
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: Align
+BreakBeforeBraces: Custom
+SortIncludes: false
+BraceWrapping:
+  AfterEnum: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterNamespace: true
+  AfterFunction: true
+  AfterStruct: true
+  AfterObjCDeclaration: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  AfterCaseLabel: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false

--- a/js/test/rive.test.ts
+++ b/js/test/rive.test.ts
@@ -1,6 +1,6 @@
-import * as rc from '../src/rive_advanced.mjs.js';
-import * as rive from '../src/rive';
-import getLongArtboardNameBuffer from './test-rive-buffers/longArtboardName';
+import * as rc from "../src/rive_advanced.mjs.js";
+import * as rive from "../src/rive";
+import getLongArtboardNameBuffer from "./test-rive-buffers/longArtboardName";
 
 // #region helper functions
 
@@ -167,8 +167,8 @@ const stateMachineFileBuffer = arrayToArrayBuffer(stateMachineFileBytes);
 
 beforeEach(() => {
   // Suppress console.warn and console.error
-  jest.spyOn(console, 'error').mockImplementation(() => {});
-  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
 });
 
 afterEach(() => {});
@@ -177,7 +177,7 @@ afterEach(() => {});
 
 // #region layout
 
-test('Layouts can be created with different fits and alignments', (): void => {
+test("Layouts can be created with different fits and alignments", (): void => {
   let layout = new rive.Layout({
     fit: rive.Fit.Contain,
     alignment: rive.Alignment.TopRight,
@@ -195,7 +195,7 @@ test('Layouts can be created with different fits and alignments', (): void => {
   expect(layout.maxY).toBe(101);
 });
 
-test('Layouts can be created with named parameters', (): void => {
+test("Layouts can be created with named parameters", (): void => {
   let layout = new rive.Layout({
     minX: 1,
     alignment: rive.Alignment.TopRight,
@@ -213,7 +213,7 @@ test('Layouts can be created with named parameters', (): void => {
   expect(layout.maxY).toBe(101);
 });
 
-test('Layouts have sensible defaults', (): void => {
+test("Layouts have sensible defaults", (): void => {
   let layout = new rive.Layout();
   expect(layout).toBeDefined();
   expect(layout.fit).toBe(rive.Fit.Contain);
@@ -224,7 +224,7 @@ test('Layouts have sensible defaults', (): void => {
   expect(layout.maxY).toBe(0);
 });
 
-test('Layouts provide runtime fit and alignment values', async () => {
+test("Layouts provide runtime fit and alignment values", async () => {
   const runtime: rc.RiveCanvas = await rive.RuntimeLoader.awaitInstance();
   let layout = new rive.Layout({
     fit: rive.Fit.FitWidth,
@@ -232,8 +232,9 @@ test('Layouts provide runtime fit and alignment values', async () => {
   });
   expect(layout).toBeDefined();
   expect(layout.runtimeFit(runtime)).toBe(runtime.Fit.fitWidth);
-  expect(layout.runtimeAlignment(runtime).x).toBe(-1);
-  expect(layout.runtimeAlignment(runtime).y).toBe(1);
+  // Now we use JSAlignment, tests not longer required
+  // expect(layout.runtimeAlignment(runtime).x).toBe(-1);
+  // expect(layout.runtimeAlignment(runtime).y).toBe(1);
 
   layout = new rive.Layout({
     fit: rive.Fit.Fill,
@@ -241,11 +242,11 @@ test('Layouts provide runtime fit and alignment values', async () => {
   });
   expect(layout).toBeDefined();
   expect(layout.runtimeFit(runtime)).toBe(runtime.Fit.fill);
-  expect(layout.runtimeAlignment(runtime).x).toBe(1);
-  expect(layout.runtimeAlignment(runtime).y).toBe(-1);
+  // expect(layout.runtimeAlignment(runtime).x).toBe(1);
+  // expect(layout.runtimeAlignment(runtime).y).toBe(-1);
 });
 
-test('Layouts can be copied with overridden values', (): void => {
+test("Layouts can be copied with overridden values", (): void => {
   let layout = new rive.Layout({
     fit: rive.Fit.ScaleDown,
     alignment: rive.Alignment.BottomRight,
@@ -273,7 +274,7 @@ test('Layouts can be copied with overridden values', (): void => {
 
 // #region runtime loading
 
-test('Runtime can be loaded using callbacks', async (done) => {
+test("Runtime can be loaded using callbacks", async (done) => {
   let callback1: rive.RuntimeCallback = (runtime: rc.RiveCanvas): void => {
     expect(runtime).toBeDefined();
     expect(runtime.Fit.none).toBeDefined();
@@ -295,7 +296,7 @@ test('Runtime can be loaded using callbacks', async (done) => {
   setTimeout(() => rive.RuntimeLoader.getInstance(callback3), 500);
 });
 
-test('Runtime can be loaded using promises', async (done) => {
+test("Runtime can be loaded using promises", async (done) => {
   let rive1: rc.RiveCanvas = await rive.RuntimeLoader.awaitInstance();
   expect(rive1).toBeDefined();
   expect(rive1.Fit.none).toBeDefined();
@@ -318,7 +319,7 @@ test('Runtime can be loaded using promises', async (done) => {
 
 // #region event
 
-test('Events can be subscribed and unsubscribed to and fired', () => {
+test("Events can be subscribed and unsubscribed to and fired", () => {
   const manager = new rive.Testing.EventManager();
   expect(manager).toBeDefined();
 
@@ -327,40 +328,40 @@ test('Events can be subscribed and unsubscribed to and fired', () => {
     type: rive.EventType.Load,
     callback: (e: rive.Event) => {
       expect(e.type).toBe(rive.EventType.Load);
-      expect(e.data).toBe('fired');
+      expect(e.data).toBe("fired");
       mockFired();
     },
   };
 
   manager.add(listener);
-  manager.fire({ type: rive.EventType.Load, data: 'fired' });
+  manager.fire({ type: rive.EventType.Load, data: "fired" });
   expect(mockFired).toBeCalledTimes(1);
 
   manager.remove(listener);
-  manager.fire({ type: rive.EventType.Load, data: 'fired' });
+  manager.fire({ type: rive.EventType.Load, data: "fired" });
   expect(mockFired).toBeCalledTimes(1);
 
   manager.add(listener);
-  manager.fire({ type: rive.EventType.Load, data: 'fired' });
+  manager.fire({ type: rive.EventType.Load, data: "fired" });
   expect(mockFired).toBeCalledTimes(2);
 });
 
-test('Creating loop event accepts enum and string values', (): void => {
+test("Creating loop event accepts enum and string values", (): void => {
   let loopEvent: rive.LoopEvent = {
-    animation: 'test animation',
+    animation: "test animation",
     type: rive.LoopType.PingPong,
   };
-  expect(loopEvent.type).toBe('pingpong');
+  expect(loopEvent.type).toBe("pingpong");
 
-  loopEvent = { animation: 'test animation', type: rive.LoopType.OneShot };
-  expect(loopEvent.type).toBe('oneshot');
+  loopEvent = { animation: "test animation", type: rive.LoopType.OneShot };
+  expect(loopEvent.type).toBe("oneshot");
 });
 
 // #endregion
 
 // #region task queue
 
-test('Tasks are queued and run when processed', () => {
+test("Tasks are queued and run when processed", () => {
   const eventManager = new rive.Testing.EventManager();
   const taskManager = new rive.Testing.TaskQueueManager(eventManager);
 
@@ -369,12 +370,12 @@ test('Tasks are queued and run when processed', () => {
     type: rive.EventType.Play,
     callback: (e: rive.Event) => {
       expect(e.type).toBe(rive.EventType.Play);
-      expect(e.data).toBe('play');
+      expect(e.data).toBe("play");
       mockFired();
     },
   };
   eventManager.add(listener);
-  const event: rive.Event = { type: rive.EventType.Play, data: 'play' };
+  const event: rive.Event = { type: rive.EventType.Play, data: "play" };
 
   const mockAction: rive.VoidCallback = jest.fn();
   const task: rive.Task = { event: event, action: mockAction };
@@ -395,16 +396,16 @@ test('Tasks are queued and run when processed', () => {
 
 // #region creating Rive objects
 
-test('Rive objects require a src url or byte buffer', () => {
-  const canvas = document.createElement('canvas');
+test("Rive objects require a src url or byte buffer", () => {
+  const canvas = document.createElement("canvas");
   const badConstructor = () => {
     new rive.Rive({ canvas: canvas });
   };
   expect(badConstructor).toThrow(Error);
 });
 
-test('Rive objects initialize correctly', (done) => {
-  const canvas = document.createElement('canvas');
+test("Rive objects initialize correctly", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: pingPongRiveFileBuffer,
@@ -416,8 +417,8 @@ test('Rive objects initialize correctly', (done) => {
   });
 });
 
-test('Corrupt Rive file cause explosions', (done) => {
-  const canvas = document.createElement('canvas');
+test("Corrupt Rive file cause explosions", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: corruptRiveFileBuffer,
@@ -430,12 +431,12 @@ test('Corrupt Rive file cause explosions', (done) => {
 
 // #region artboards
 
-test('Artboards can be fetched by name', (done) => {
-  const canvas = document.createElement('canvas');
+test("Artboards can be fetched by name", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
-    artboard: 'Artboard2',
+    artboard: "Artboard2",
     onLoad: () => {
       expect(r).toBeDefined();
       done();
@@ -444,12 +445,12 @@ test('Artboards can be fetched by name', (done) => {
   });
 });
 
-test('Artboards can be fetched with a long name', (done) => {
-  const canvas = document.createElement('canvas');
+test("Artboards can be fetched with a long name", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: arrayToArrayBuffer(getLongArtboardNameBuffer()),
-    artboard: 'Really Long  Artboard Name with Double Spaces',
+    artboard: "Really Long  Artboard Name with Double Spaces",
     onLoad: () => {
       expect(r).toBeDefined();
       done();
@@ -457,12 +458,12 @@ test('Artboards can be fetched with a long name', (done) => {
   });
 });
 
-test('Rive explodes when given an invalid artboard name', (done) => {
-  const canvas = document.createElement('canvas');
+test("Rive explodes when given an invalid artboard name", (done) => {
+  const canvas = document.createElement("canvas");
   new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
-    artboard: 'BadArtboard',
+    artboard: "BadArtboard",
     onLoad: () => expect(false).toBeTruthy(),
     onLoadError: () => {
       // We should get here
@@ -471,11 +472,11 @@ test('Rive explodes when given an invalid artboard name', (done) => {
   });
 });
 
-test('Artboard bounds can be retrieved from a loaded Rive file', (done) => {
-  const canvas = document.createElement('canvas');
+test("Artboard bounds can be retrieved from a loaded Rive file", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
-    artboard: 'MyArtboard',
+    artboard: "MyArtboard",
     buffer: stateMachineFileBuffer,
     onLoad: () => {
       const bounds = r.bounds;
@@ -493,8 +494,8 @@ test('Artboard bounds can be retrieved from a loaded Rive file', (done) => {
 
 // #region playbackstates
 
-test('Playback state for new Rive objects is pause', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playback state for new Rive objects is pause", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: pingPongRiveFileBuffer,
@@ -507,8 +508,8 @@ test('Playback state for new Rive objects is pause', (done) => {
   });
 });
 
-test('Playback state for auto-playing new Rive objects is play', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playback state for auto-playing new Rive objects is play", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: pingPongRiveFileBuffer,
@@ -533,8 +534,8 @@ test('Playback state for auto-playing new Rive objects is play', (done) => {
 
 // #region Firing events
 
-test('Playing a ping-pong animation will fire a loop event', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing a ping-pong animation will fire a loop event", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: pingPongRiveFileBuffer,
@@ -555,8 +556,8 @@ test('Playing a ping-pong animation will fire a loop event', (done) => {
   });
 });
 
-test('Playing a loop animation will fire a loop event', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing a loop animation will fire a loop event", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: loopRiveFileBuffer,
@@ -577,8 +578,8 @@ test('Playing a loop animation will fire a loop event', (done) => {
   });
 });
 
-test('Playing a one-shot animation will fire a stop event', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing a one-shot animation will fire a stop event", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: oneShotRiveFileBuffer,
@@ -597,8 +598,8 @@ test('Playing a one-shot animation will fire a stop event', (done) => {
   });
 });
 
-test('Stop events are received', (done) => {
-  const canvas = document.createElement('canvas');
+test("Stop events are received", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: oneShotRiveFileBuffer,
@@ -613,8 +614,8 @@ test('Stop events are received', (done) => {
   });
 });
 
-test('Events can be unsubscribed from', (done) => {
-  const canvas = document.createElement('canvas');
+test("Events can be unsubscribed from", (done) => {
+  const canvas = document.createElement("canvas");
 
   const stopCallback = (event: rive.Event) =>
     // We should never reach this
@@ -634,8 +635,8 @@ test('Events can be unsubscribed from', (done) => {
   setTimeout(() => done(), 200);
 });
 
-test('Events of a single type can be mass unsubscribed', (done) => {
-  const canvas = document.createElement('canvas');
+test("Events of a single type can be mass unsubscribed", (done) => {
+  const canvas = document.createElement("canvas");
 
   const loopCallback1 = (event: rive.Event) => expect(false).toBeTruthy();
   const loopCallback2 = (event: rive.Event) => expect(false).toBeTruthy();
@@ -661,8 +662,8 @@ test('Events of a single type can be mass unsubscribed', (done) => {
   setTimeout(() => r.stop(), 200);
 });
 
-test('All events can be mass unsubscribed', (done) => {
-  const canvas = document.createElement('canvas');
+test("All events can be mass unsubscribed", (done) => {
+  const canvas = document.createElement("canvas");
 
   const loopCallback1 = (event: rive.Event) => expect(false).toBeTruthy();
   const loopCallback2 = (event: rive.Event) => expect(false).toBeTruthy();
@@ -695,8 +696,8 @@ test('All events can be mass unsubscribed', (done) => {
 
 // #region playback control
 
-test('Playing animations can be manually started and stopped', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing animations can be manually started and stopped", (done) => {
+  const canvas = document.createElement("canvas");
 
   const r = new rive.Rive({
     canvas: canvas,
@@ -727,8 +728,8 @@ test('Playing animations can be manually started and stopped', (done) => {
   });
 });
 
-test('Playing animations can be manually started, paused, and restarted', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing animations can be manually started, paused, and restarted", (done) => {
+  const canvas = document.createElement("canvas");
   let hasLooped = false;
 
   const r = new rive.Rive({
@@ -770,8 +771,8 @@ test('Playing animations can be manually started, paused, and restarted', (done)
 
 // #region loading files
 
-test('Multiple files can be loaded and played', (done) => {
-  const canvas = document.createElement('canvas');
+test("Multiple files can be loaded and played", (done) => {
+  const canvas = document.createElement("canvas");
   let loopOccurred = false;
   let firstLoadOccurred = false;
 
@@ -810,8 +811,8 @@ test('Multiple files can be loaded and played', (done) => {
   });
 });
 
-test('Layout is set to canvas dimensions if not specified', (done) => {
-  const canvas = document.createElement('canvas');
+test("Layout is set to canvas dimensions if not specified", (done) => {
+  const canvas = document.createElement("canvas");
   canvas.width = 400;
   canvas.height = 300;
 
@@ -832,8 +833,8 @@ test('Layout is set to canvas dimensions if not specified', (done) => {
 
 // #region Rive properties
 
-test('Rive file contents can be read', (done) => {
-  const canvas = document.createElement('canvas');
+test("Rive file contents can be read", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
@@ -842,31 +843,31 @@ test('Rive file contents can be read', (done) => {
       expect(contents).toBeDefined();
       expect(contents.artboards).toBeDefined();
       expect(contents.artboards).toHaveLength(2);
-      expect(contents.artboards[0].name).toBe('MyArtboard');
-      expect(contents.artboards[1].name).toBe('Artboard2');
+      expect(contents.artboards[0].name).toBe("MyArtboard");
+      expect(contents.artboards[1].name).toBe("Artboard2");
       expect(contents.artboards[0].animations).toBeDefined();
       expect(contents.artboards[0].animations).toHaveLength(6);
       expect(contents.artboards[0].animations[0]).toBe(
-        'WorkAreaPingPongAnimation'
+        "WorkAreaPingPongAnimation"
       );
       expect(contents.artboards[0].stateMachines).toBeDefined();
       expect(contents.artboards[0].stateMachines).toHaveLength(1);
-      expect(contents.artboards[0].stateMachines[0].name).toBe('StateMachine');
+      expect(contents.artboards[0].stateMachines[0].name).toBe("StateMachine");
       expect(contents.artboards[0].stateMachines[0].inputs).toHaveLength(3);
       expect(contents.artboards[0].stateMachines[0].inputs[0].name).toBe(
-        'MyNum'
+        "MyNum"
       );
       expect(contents.artboards[0].stateMachines[0].inputs[0].type).toBe(
         rive.StateMachineInputType.Number
       );
       expect(contents.artboards[0].stateMachines[0].inputs[1].name).toBe(
-        'MyBool'
+        "MyBool"
       );
       expect(contents.artboards[0].stateMachines[0].inputs[1].type).toBe(
         rive.StateMachineInputType.Boolean
       );
       expect(contents.artboards[0].stateMachines[0].inputs[2].name).toBe(
-        'MyTrig'
+        "MyTrig"
       );
       expect(contents.artboards[0].stateMachines[0].inputs[2].type).toBe(
         rive.StateMachineInputType.Trigger
@@ -880,26 +881,26 @@ test('Rive file contents can be read', (done) => {
 
 // #region state machine
 
-test('State machine names can be retrieved', (done) => {
-  const canvas = document.createElement('canvas');
+test("State machine names can be retrieved", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
     onLoad: () => {
       const stateMachineNames = r.stateMachineNames;
       expect(stateMachineNames).toHaveLength(1);
-      expect(stateMachineNames[0]).toBe('StateMachine');
+      expect(stateMachineNames[0]).toBe("StateMachine");
       done();
     },
   });
 });
 
-test('State machines can be instanced', (done) => {
-  const canvas = document.createElement('canvas');
+test("State machines can be instanced", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
-    stateMachines: 'StateMachine',
+    stateMachines: "StateMachine",
     onPause: () => {
       expect(r.pausedStateMachineNames).toHaveLength(1);
       done();
@@ -907,22 +908,22 @@ test('State machines can be instanced', (done) => {
   });
 });
 
-test('Instanced state machine inputs can be retrieved', (done) => {
-  const canvas = document.createElement('canvas');
+test("Instanced state machine inputs can be retrieved", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
-    stateMachines: 'StateMachine',
+    stateMachines: "StateMachine",
     onPause: () => {
-      let stateMachineInputs = r.stateMachineInputs('BadName');
+      let stateMachineInputs = r.stateMachineInputs("BadName");
       expect(stateMachineInputs).toBeUndefined();
-      stateMachineInputs = r.stateMachineInputs('StateMachine');
+      stateMachineInputs = r.stateMachineInputs("StateMachine");
       expect(stateMachineInputs).toHaveLength(3);
 
       expect(stateMachineInputs[0].type).toBe(
         rive.StateMachineInputType.Number
       );
-      expect(stateMachineInputs[0].name).toBe('MyNum');
+      expect(stateMachineInputs[0].name).toBe("MyNum");
       expect(stateMachineInputs[0].value).toBe(0);
       stateMachineInputs[0].value = 12;
       expect(stateMachineInputs[0].value).toBe(12);
@@ -930,7 +931,7 @@ test('Instanced state machine inputs can be retrieved', (done) => {
       expect(stateMachineInputs[1].type).toBe(
         rive.StateMachineInputType.Boolean
       );
-      expect(stateMachineInputs[1].name).toBe('MyBool');
+      expect(stateMachineInputs[1].name).toBe("MyBool");
       expect(stateMachineInputs[1].value).toBe(false);
       stateMachineInputs[1].value = true;
       expect(stateMachineInputs[1].value).toBe(true);
@@ -938,7 +939,7 @@ test('Instanced state machine inputs can be retrieved', (done) => {
       expect(stateMachineInputs[2].type).toBe(
         rive.StateMachineInputType.Trigger
       );
-      expect(stateMachineInputs[2].name).toBe('MyTrig');
+      expect(stateMachineInputs[2].name).toBe("MyTrig");
       expect(stateMachineInputs[2].value).toBeUndefined();
       expect(stateMachineInputs[2].fire()).toBeUndefined();
 
@@ -947,14 +948,14 @@ test('Instanced state machine inputs can be retrieved', (done) => {
   });
 });
 
-test('Playing state machines can be manually started, paused, and restarted', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing state machines can be manually started, paused, and restarted", (done) => {
+  const canvas = document.createElement("canvas");
   let hasPaused = false;
 
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
-    stateMachines: 'StateMachine',
+    stateMachines: "StateMachine",
     onLoad: () => {
       // Nothing should be playing whenever a file is loaded
       expect(r.isStopped).toBeFalsy();
@@ -977,25 +978,25 @@ test('Playing state machines can be manually started, paused, and restarted', (d
   });
 });
 
-test('Playing state machines report when states have changed', (done) => {
-  const canvas = document.createElement('canvas');
+test("Playing state machines report when states have changed", (done) => {
+  const canvas = document.createElement("canvas");
   let state = 0;
 
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
-    artboard: 'MyArtboard',
-    stateMachines: 'StateMachine',
+    artboard: "MyArtboard",
+    stateMachines: "StateMachine",
     autoplay: true,
     onPlay: () => {
       // Expect the correct animation to be playing
       expect(r.playingStateMachineNames).toHaveLength(1);
-      expect(r.playingStateMachineNames[0]).toBe('StateMachine');
+      expect(r.playingStateMachineNames[0]).toBe("StateMachine");
       // Check the inputs are correct
       const inputs = r.stateMachineInputs(r.playingStateMachineNames[0]);
       expect(inputs).toHaveLength(3);
-      expect(inputs[1].name).toBe('MyBool');
-      expect(inputs[2].name).toBe('MyTrig');
+      expect(inputs[1].name).toBe("MyBool");
+      expect(inputs[2].name).toBe("MyTrig");
     },
     onStateChange: ({ type: type, data: stateNames }) => {
       const inputs = r.stateMachineInputs(r.playingStateMachineNames[0]);
@@ -1003,19 +1004,19 @@ test('Playing state machines report when states have changed', (done) => {
       if (state === 0) {
         // console.log(`State: ${(stateNames as string[])[0]}`);
         expect(stateNames).toHaveLength(1);
-        expect((stateNames as string[])[0]).toBe('LoopingAnimation');
+        expect((stateNames as string[])[0]).toBe("LoopingAnimation");
 
         state++;
         inputs[2].fire();
       } else if (state === 1) {
         expect(stateNames).toHaveLength(1);
-        expect((stateNames as string[])[0]).toBe('PingPongAnimation');
+        expect((stateNames as string[])[0]).toBe("PingPongAnimation");
 
         state++;
         inputs[1].value = true;
       } else if (state === 2) {
         expect(stateNames).toHaveLength(1);
-        expect((stateNames as string[])[0]).toBe('exit');
+        expect((stateNames as string[])[0]).toBe("exit");
 
         done();
       }
@@ -1027,8 +1028,8 @@ test('Playing state machines report when states have changed', (done) => {
 
 // #region scrubbing
 
-test('An animation can be played and scrubbed without altering playback state', (done) => {
-  const canvas = document.createElement('canvas');
+test("An animation can be played and scrubbed without altering playback state", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
@@ -1055,8 +1056,8 @@ test('An animation can be played and scrubbed without altering playback state', 
 
 // #region reseting
 
-test('Artboards can be reset back to their starting state', (done) => {
-  const canvas = document.createElement('canvas');
+test("Artboards can be reset back to their starting state", (done) => {
+  const canvas = document.createElement("canvas");
 
   // Track the nr of loops
   let loopCount: number = 0;
@@ -1068,7 +1069,7 @@ test('Artboards can be reset back to their starting state', (done) => {
     autoplay: true,
     onLoad: () => {
       // Default artboard should be selected
-      expect(r.activeArtboard).toBe('New Artboard');
+      expect(r.activeArtboard).toBe("New Artboard");
       // This should only ever happen once
       expect(loopCount).toBe(0);
     },
@@ -1088,8 +1089,8 @@ test('Artboards can be reset back to their starting state', (done) => {
 
 // #region remove mouse events
 
-test('Mouse events are removed from canvas when reset', (done) => {
-  const canvas = document.createElement('canvas');
+test("Mouse events are removed from canvas when reset", (done) => {
+  const canvas = document.createElement("canvas");
   let resetMe = true;
 
   // Start up a looping animation
@@ -1097,15 +1098,15 @@ test('Mouse events are removed from canvas when reset', (done) => {
     canvas: canvas,
     buffer: stateMachineFileBuffer,
     autoplay: true,
-    artboard: 'MyArtboard',
-    stateMachines: 'StateMachine',
+    artboard: "MyArtboard",
+    stateMachines: "StateMachine",
     onStateChange: () => {
       // lets make sure we're moving so we got things registered
       if (resetMe) {
         resetMe = false;
         r.reset({
-          artboard: 'MyArtboard',
-          stateMachines: 'StateMachine',
+          artboard: "MyArtboard",
+          stateMachines: "StateMachine",
           autoplay: true,
         });
       }
@@ -1113,7 +1114,7 @@ test('Mouse events are removed from canvas when reset', (done) => {
         try {
           // This will fake a mouse event, and trigger their event handlers
           // If those are illegal, we'll crash
-          canvas.dispatchEvent(new Event('mousedown'));
+          canvas.dispatchEvent(new Event("mousedown"));
         } catch (err) {
           done(err);
         }
@@ -1125,7 +1126,7 @@ test('Mouse events are removed from canvas when reset', (done) => {
 
 // #endregion
 
-test('Statemachines have pointer events', (done) => {
+test("Statemachines have pointer events", (done) => {
   rive.RuntimeLoader.awaitInstance().then(async (runtime) => {
     const file = await runtime.load(new Uint8Array(stateMachineFileBuffer));
     const ab = file.artboardByIndex(0);
@@ -1145,17 +1146,17 @@ test('Statemachines have pointer events', (done) => {
 
 // #region cleanup
 
-test('Rive deletes instances on the cleanup', (done) => {
-  const canvas = document.createElement('canvas');
+test("Rive deletes instances on the cleanup", (done) => {
+  const canvas = document.createElement("canvas");
   const r = new rive.Rive({
     canvas: canvas,
     buffer: stateMachineFileBuffer,
     autoplay: true,
-    artboard: 'MyArtboard',
+    artboard: "MyArtboard",
     onLoad: () => {
-      expect(r.activeArtboard).toBe('MyArtboard');
+      expect(r.activeArtboard).toBe("MyArtboard");
       r.cleanup();
-      expect(r.activeArtboard).toBe('');
+      expect(r.activeArtboard).toBe("");
       done();
     },
   });

--- a/wasm/build_wasm.sh
+++ b/wasm/build_wasm.sh
@@ -43,3 +43,11 @@ elif [ "$OPTION" = "release" ]; then
 else
     premake5 gmake2 $PREMAKE_FLAGS && AR=emar CC=emcc CXX=em++ make -j$NCPU
 fi
+
+# If you want to run the leak checker with debug symbols, copy
+# canvas_advanced.wasm to the parcel example's assets folder. Commented out for
+# now as it should only happen if you're not building single and the canvas
+# version.
+# ----
+# du build/bin/debug/canvas_advanced.wasm
+# cp build/bin/debug/canvas_advanced.wasm examples/parcel_example/assets/canvas_advanced.wasm

--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -874,4 +874,10 @@ Rive.onRuntimeInitialized = function () {
   );
   Rive["disableFPSCounter"] = _animationCallbackHandler.disableFPSCounter;
   _animationCallbackHandler.onAfterCallbacks = flushCanvasRenderers;
+
+  Rive["cleanup"] = function () {
+    if (_rectanizer) {
+      _rectanizer.delete();
+    }
+  };
 };

--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -1,133 +1,169 @@
-workspace "rive"
-configurations {"debug", "release"}
+workspace 'rive'
+configurations {'debug', 'release'}
 
-project "rive"
-kind "ConsoleApp"
-language "C++"
-cppdialect "C++17"
-targetdir ((os.getenv("OUT_DIR") or "build") .. "/bin/%{cfg.buildcfg}")
-objdir ((os.getenv("OUT_DIR") or "build") .. "/obj/%{cfg.buildcfg}")
-includedirs {"./submodules/rive-cpp/include"}
+project 'rive'
 
-files {"./submodules/rive-cpp/src/**.cpp", "./src/*.cpp"}
+kind 'ConsoleApp'
+language 'C++'
+cppdialect 'C++17'
+targetdir((os.getenv('OUT_DIR') or 'build') .. '/bin/%{cfg.buildcfg}')
+objdir((os.getenv('OUT_DIR') or 'build') .. '/obj/%{cfg.buildcfg}')
+includedirs {'./submodules/rive-cpp/include'}
+
+files {'./submodules/rive-cpp/src/**.cpp', './src/*.cpp'}
 
 buildoptions {
-            "-Oz", 
-            "-g0",
-            "-s STRICT=1",
-            "-s DISABLE_EXCEPTION_CATCHING=1", 
-            "-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0", 
-            "-DSINGLE",
-            "-DANSI_DECLARATORS", 
-            "-Wno-c++17-extensions", 
-            "-fno-exceptions", 
-            "-fno-rtti", 
-            "-flto",
-            "-fno-unwind-tables",
-            "--no-entry"
-        }
+    '-s STRICT=1',
+    '-s DISABLE_EXCEPTION_CATCHING=1',
+    '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0',
+    '-DSINGLE',
+    '-DANSI_DECLARATORS',
+    '-Wno-c++17-extensions',
+    '-fno-exceptions',
+    '-fno-rtti',
+    '-fno-unwind-tables',
+    '--no-entry'
+}
 
 linkoptions {
-            "-Oz", 
-            "-g0", 
-            "--closure 1",
-            "--bind", 
-            "-s ASSERTIONS=0",
-            "-s FORCE_FILESYSTEM=0", 
-            "-s MODULARIZE=1", 
-            "-s NO_EXIT_RUNTIME=1", 
-            "-s STRICT=1", 
-            "-flto",
-            "-s DYNAMIC_EXECUTION=0",
-            "-s ALLOW_MEMORY_GROWTH=1", 
-            "-s DISABLE_EXCEPTION_CATCHING=1", 
-            "-s WASM=1", 
-            -- "-s EXPORT_ES6=1",
-            "-s USE_ES6_IMPORT_META=0", 
-            "-s EXPORT_NAME=\"Rive\"", 
-            "-s ENVIRONMENT=\"web,webview,worker\"",
-            "-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0", 
-            "-DSINGLE",
-            "-DANSI_DECLARATORS", 
-            "-Wno-c++17-extensions", 
-            "-fno-exceptions", 
-            "-fno-rtti", 
-            "-fno-unwind-tables",
-            "--no-entry"
-        }
+    '--bind',
+    '-s FORCE_FILESYSTEM=0',
+    '-s MODULARIZE=1',
+    '-s NO_EXIT_RUNTIME=1',
+    '-s STRICT=1',
+    '-s DYNAMIC_EXECUTION=0',
+    '-s ALLOW_MEMORY_GROWTH=1',
+    '-s DISABLE_EXCEPTION_CATCHING=1',
+    '-s WASM=1',
+    -- "-s EXPORT_ES6=1",
+    '-s USE_ES6_IMPORT_META=0',
+    '-s EXPORT_NAME="Rive"',
+    '-s ENVIRONMENT="web,webview,worker"',
+    '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0',
+    '-DSINGLE',
+    '-DANSI_DECLARATORS',
+    '-Wno-c++17-extensions',
+    '-fno-exceptions',
+    '-fno-rtti',
+    '-fno-unwind-tables',
+    '--no-entry'
+}
 
-filter { "options:not skia", "options:not single_file" }
+filter {'options:not skia', 'options:not single_file'}
+do
     linkoptions {
-            "--pre-js ./js/animation_callback_handler.js",
-            "--pre-js ./js/max_recent_size.js",
-            "--pre-js ./js/renderer.js",
-            "-o %{cfg.targetdir}/canvas_advanced.mjs",
-        }
-
-filter { "options:not skia", "options:single_file" }
-    linkoptions {
-            "--pre-js ./js/animation_callback_handler.js",
-            "--pre-js ./js/max_recent_size.js",
-            "--pre-js ./js/renderer.js",
-            "-o %{cfg.targetdir}/canvas_advanced_single.mjs",
-        }
-
-
-filter { "options:skia", "options:single_file" }
-    linkoptions {
-        "-o %{cfg.targetdir}/webgl_advanced_single.mjs",
+        '--pre-js ./js/animation_callback_handler.js',
+        '--pre-js ./js/max_recent_size.js',
+        '--pre-js ./js/renderer.js',
+        '-o %{cfg.targetdir}/canvas_advanced.mjs'
     }
+end
 
-filter { "options:skia", "options:not single_file" }
+filter {'options:not skia', 'options:single_file'}
+do
     linkoptions {
-        "-o %{cfg.targetdir}/webgl_advanced.mjs",
+        '--pre-js ./js/animation_callback_handler.js',
+        '--pre-js ./js/max_recent_size.js',
+        '--pre-js ./js/renderer.js',
+        '-o %{cfg.targetdir}/canvas_advanced_single.mjs'
     }
+end
 
-filter "options:skia"
-    defines {"RIVE_SKIA_RENDERER"}
-    buildoptions { "-DSK_GL", "-DSK_SUPPORT_GPU=1" }
-    includedirs {"./submodules/rive-cpp/skia/renderer/include", 
-                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized",
-                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/core",
-                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/effects",
-                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/gpu",
-                "./submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/config"}
-    files {"./submodules/rive-cpp/skia/renderer/src/**.cpp"}
-    libdirs {"submodules/rive-cpp/skia/dependencies/skia_rive_optimized/out/wasm/"}
-    links {"skia", "GL"}
+filter {'options:skia', 'options:single_file'}
+do
     linkoptions {
-            "-s USE_WEBGL2=1",
-            "-s MIN_WEBGL_VERSION=1",
-            "-s MAX_WEBGL_VERSION=2",
-            "--pre-js ./js/animation_callback_handler.js",
-            "--pre-js ./js/max_recent_size.js",
-            "--pre-js ./js/skia_renderer.js"
-        }
+        '-o %{cfg.targetdir}/webgl_advanced_single.mjs'
+    }
+end
 
-filter "options:not skia"
-    includedirs {"./src/skia_imports", }
-    files {"./src/skia_imports/**.cpp"}
+filter {'options:skia', 'options:not single_file'}
+do
+    linkoptions {
+        '-o %{cfg.targetdir}/webgl_advanced.mjs'
+    }
+end
 
-filter "options:single_file"
-        linkoptions {
-            "-s SINGLE_FILE=1"
-        }
+filter 'options:skia'
+do
+    defines {'RIVE_SKIA_RENDERER'}
+    buildoptions {'-DSK_GL', '-DSK_SUPPORT_GPU=1'}
+    includedirs {
+        './submodules/rive-cpp/skia/renderer/include',
+        './submodules/rive-cpp/skia/dependencies/skia_rive_optimized',
+        './submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/core',
+        './submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/effects',
+        './submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/gpu',
+        './submodules/rive-cpp/skia/dependencies/skia_rive_optimized/include/config'
+    }
+    files {'./submodules/rive-cpp/skia/renderer/src/**.cpp'}
+    libdirs {'submodules/rive-cpp/skia/dependencies/skia_rive_optimized/out/wasm/'}
+    links {'skia', 'GL'}
+    linkoptions {
+        '-s USE_WEBGL2=1',
+        '-s MIN_WEBGL_VERSION=1',
+        '-s MAX_WEBGL_VERSION=2',
+        '--pre-js ./js/animation_callback_handler.js',
+        '--pre-js ./js/max_recent_size.js',
+        '--pre-js ./js/skia_renderer.js'
+    }
+end
 
-filter "configurations:debug"
-defines {"DEBUG"}
-symbols "On"
+filter 'options:not skia'
+do
+    includedirs {'./src/skia_imports'}
+    files {'./src/skia_imports/**.cpp'}
+end
 
-filter "configurations:release"
-defines {"RELEASE"}
-defines {"NDEBUG"}
-optimize "On"
+filter 'options:single_file'
+do
+    linkoptions {
+        '-s SINGLE_FILE=1'
+    }
+end
+
+filter 'configurations:debug'
+do
+    defines {'DEBUG'}
+    symbols 'On'
+    buildoptions {
+        '-g2',
+        '-fsanitize=address'
+    }
+    linkoptions {
+        '-s ERROR_ON_UNDEFINED_SYMBOLS=0',
+        '-s ASSERTIONS=1',
+        '-s ABORTING_MALLOC=0',
+        '-s DEMANGLE_SUPPORT=1',
+        '-g2',
+        '-fsanitize=address'
+    }
+end
+
+filter 'configurations:release'
+do
+    defines {'RELEASE'}
+    defines {'NDEBUG'}
+    optimize 'On'
+    buildoptions {
+        '-flto',
+        '-Oz',
+        '-g0'
+    }
+    linkoptions {
+        '-s ASSERTIONS=0',
+        '--closure 1',
+        '-flto',
+        '-Oz',
+        '-g0'
+    }
+end
 
 newoption {
-    trigger = "skia",
-    description = "Set when linking with Skia."
+    trigger = 'skia',
+    description = 'Set when linking with Skia.'
 }
 
 newoption {
-    trigger = "single_file",
-    description = "Set when the wasm should be packed in with the js code."
+    trigger = 'single_file',
+    description = 'Set when the wasm should be packed in with the js code.'
 }

--- a/wasm/src/bindings.cpp
+++ b/wasm/src/bindings.cpp
@@ -26,6 +26,8 @@
 #include "rive/shapes/path.hpp"
 #include "rive/transform_component.hpp"
 
+#include "js_alignment.hpp"
+
 #include "src/core/SkIPoint16.h"
 #include "src/gpu/GrDynamicRectanizer.h"
 
@@ -36,6 +38,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
+#include <sanitizer/lsan_interface.h>
 
 using namespace emscripten;
 
@@ -48,440 +51,446 @@ extern rive::Factory* jsFactory();
 // for other people suffering our same pains.
 const uint16_t stateMachineBoolTypeKey = rive::StateMachineBoolBase::typeKey;
 
-const uint16_t stateMachineNumberTypeKey =
-    rive::StateMachineNumberBase::typeKey;
+const uint16_t stateMachineNumberTypeKey = rive::StateMachineNumberBase::typeKey;
 
-const uint16_t stateMachineTriggerTypeKey =
-    rive::StateMachineTriggerBase::typeKey;
+const uint16_t stateMachineTriggerTypeKey = rive::StateMachineTriggerBase::typeKey;
 
-rive::File *load(emscripten::val byteArray) {
-  std::vector<unsigned char> rv;
+rive::File* load(emscripten::val byteArray)
+{
+    std::vector<unsigned char> rv;
 
-  const auto l = byteArray["byteLength"].as<unsigned>();
-  rv.resize(l);
+    const auto l = byteArray["byteLength"].as<unsigned>();
+    rv.resize(l);
 
-  emscripten::val memoryView{emscripten::typed_memory_view(l, rv.data())};
-  memoryView.call<void>("set", byteArray);
-  return rive::File::import(rv, jsFactory()).release();
+    emscripten::val memoryView{emscripten::typed_memory_view(l, rv.data())};
+    memoryView.call<void>("set", byteArray);
+    return rive::File::import(rv, jsFactory()).release();
 }
 
-rive::Mat2D computeAlignment(rive::Fit fit, rive::Alignment alignment, rive::AABB orig, rive::AABB dest) {
-  return rive::computeAlignment(fit, alignment, orig, dest);
+rive::Alignment convertAlignment(JsAlignment alignment)
+{
+    switch (alignment)
+    {
+        case JsAlignment::topLeft:
+            return rive::Alignment::topLeft;
+        case JsAlignment::topCenter:
+            return rive::Alignment::topCenter;
+        case JsAlignment::topRight:
+            return rive::Alignment::topRight;
+        case JsAlignment::centerLeft:
+            return rive::Alignment::centerLeft;
+        case JsAlignment::center:
+            return rive::Alignment::center;
+        case JsAlignment::centerRight:
+            return rive::Alignment::centerRight;
+        case JsAlignment::bottomLeft:
+            return rive::Alignment::bottomLeft;
+        case JsAlignment::bottomCenter:
+            return rive::Alignment::bottomCenter;
+        case JsAlignment::bottomRight:
+            return rive::Alignment::bottomRight;
+    }
+    return rive::Alignment::center;
 }
 
-rive::Vec2D mapXY(rive::Mat2D invertedMatrix, rive::Vec2D canvasVector) {
-  return invertedMatrix * canvasVector;
+rive::Mat2D computeAlignment(rive::Fit fit, JsAlignment alignment, rive::AABB orig, rive::AABB dest)
+{
+    return rive::computeAlignment(fit, convertAlignment(alignment), orig, dest);
 }
 
-class DynamicRectanizer {
+rive::Vec2D mapXY(rive::Mat2D invertedMatrix, rive::Vec2D canvasVector)
+{
+    return invertedMatrix * canvasVector;
+}
+
+class DynamicRectanizer
+{
 public:
-  DynamicRectanizer(int maxAtlasSize) :
-      m_Rectanizer(SkISize(),
-                   maxAtlasSize,
-                   GrDynamicRectanizer::RectanizerAlgorithm::kSkyline) {}
+    DynamicRectanizer(int maxAtlasSize) :
+        m_Rectanizer(SkISize::Make(1, 1),
+                     maxAtlasSize,
+                     GrDynamicRectanizer::RectanizerAlgorithm::kSkyline)
+    {}
 
-  void reset(int initialWidth, int initialHeight) {
-      m_Rectanizer.reset({initialWidth, initialHeight});
-  }
+    void reset(int initialWidth, int initialHeight)
+    {
+        m_Rectanizer.reset({initialWidth, initialHeight});
+    }
 
-  int addRect(int width, int height) {
-      SkIPoint16 loc;
-      if (!m_Rectanizer.addRect(width, height, &loc)) {
-          return -1;
-      }
-      return (loc.y() << 16) | loc.x();
-  }
+    int addRect(int width, int height)
+    {
+        SkIPoint16 loc;
+        if (!m_Rectanizer.addRect(width, height, &loc))
+        {
+            return -1;
+        }
+        return (loc.y() << 16) | loc.x();
+    }
 
-  int drawWidth() const { return m_Rectanizer.drawBounds().width(); }
+    int drawWidth() const { return m_Rectanizer.drawBounds().width(); }
 
-  int drawHeight() const { return m_Rectanizer.drawBounds().height(); }
+    int drawHeight() const { return m_Rectanizer.drawBounds().height(); }
 
 private:
-  GrDynamicRectanizer m_Rectanizer;
+    GrDynamicRectanizer m_Rectanizer;
 };
 
-EMSCRIPTEN_BINDINGS(RiveWASM) {
-  function("load", &load, allow_raw_pointers());
-  function("computeAlignment", &computeAlignment);
-  function("mapXY", &mapXY);
+EMSCRIPTEN_BINDINGS(RiveWASM)
+{
+    function("load", &load, allow_raw_pointers());
+    function("computeAlignment", &computeAlignment);
+    function("mapXY", &mapXY);
 
 #ifdef ENABLE_QUERY_FLAT_VERTICES
-  class_<rive::FlattenedPath>("FlattenedPath")
-      .function("length",
-                optional_override([](rive::FlattenedPath &self) -> size_t {
-                  return self.vertices().size();
-                }))
-      .function("isCubic", optional_override([](rive::FlattenedPath &self,
-                                                size_t index) -> bool {
-                  if (index >= self.vertices().size()) {
-                    return false;
-                  }
-                  return self.vertices()[index]->is<rive::CubicVertex>();
-                }))
-      .function("x", optional_override(
-                         [](rive::FlattenedPath &self, size_t index) -> float {
-                           return self.vertices()[index]->x();
-                         }))
-      .function("y", optional_override(
-                         [](rive::FlattenedPath &self, size_t index) -> float {
-                           return self.vertices()[index]->y();
-                         }))
-      .function("inX", optional_override([](rive::FlattenedPath &self,
-                                            size_t index) -> float {
-                  return self.vertices()[index]
-                      ->as<rive::CubicVertex>()
-                      ->renderIn()[0];
-                }))
-      .function("inY", optional_override([](rive::FlattenedPath &self,
-                                            size_t index) -> float {
-                  return self.vertices()[index]
-                      ->as<rive::CubicVertex>()
-                      ->renderIn()[1];
-                }))
-      .function("outX", optional_override([](rive::FlattenedPath &self,
-                                             size_t index) -> float {
-                  return self.vertices()[index]
-                      ->as<rive::CubicVertex>()
-                      ->renderOut()[0];
-                }))
-      .function("outY", optional_override([](rive::FlattenedPath &self,
-                                             size_t index) -> float {
-                  return self.vertices()[index]
-                      ->as<rive::CubicVertex>()
-                      ->renderOut()[1];
-                }));
+    class_<rive::FlattenedPath>("FlattenedPath")
+        .function("length", optional_override([](rive::FlattenedPath& self) -> size_t {
+                      return self.vertices().size();
+                  }))
+        .function("isCubic", optional_override([](rive::FlattenedPath& self, size_t index) -> bool {
+                      if (index >= self.vertices().size())
+                      {
+                          return false;
+                      }
+                      return self.vertices()[index]->is<rive::CubicVertex>();
+                  }))
+        .function("x", optional_override([](rive::FlattenedPath& self, size_t index) -> float {
+                      return self.vertices()[index]->x();
+                  }))
+        .function("y", optional_override([](rive::FlattenedPath& self, size_t index) -> float {
+                      return self.vertices()[index]->y();
+                  }))
+        .function("inX", optional_override([](rive::FlattenedPath& self, size_t index) -> float {
+                      return self.vertices()[index]->as<rive::CubicVertex>()->renderIn()[0];
+                  }))
+        .function("inY", optional_override([](rive::FlattenedPath& self, size_t index) -> float {
+                      return self.vertices()[index]->as<rive::CubicVertex>()->renderIn()[1];
+                  }))
+        .function("outX", optional_override([](rive::FlattenedPath& self, size_t index) -> float {
+                      return self.vertices()[index]->as<rive::CubicVertex>()->renderOut()[0];
+                  }))
+        .function("outY", optional_override([](rive::FlattenedPath& self, size_t index) -> float {
+                      return self.vertices()[index]->as<rive::CubicVertex>()->renderOut()[1];
+                  }));
 #endif
 
-  class_<rive::Vec2D>("Vec2D")
-    .constructor<float, float>()
-    // TODO: For next major verison, make these properties instead of methods to match
-    // patterns on other math-based Rive classes, such as Mat2D
-    .function("x", optional_override([](rive::Vec2D self) -> float { return self.x; }))
-    .function("y", optional_override([](rive::Vec2D self) -> float { return self.y; }));
+    class_<rive::Vec2D>("Vec2D")
+        .constructor<float, float>()
+        // TODO: For next major verison, make these properties instead of methods to match
+        // patterns on other math-based Rive classes, such as Mat2D
+        .function("x", optional_override([](rive::Vec2D self) -> float { return self.x; }))
+        .function("y", optional_override([](rive::Vec2D self) -> float { return self.y; }));
 
-  class_<rive::Mat2D>("Mat2D")
-      .constructor<>()
-      .property("xx", select_overload<float() const>(&rive::Mat2D::xx),
-                select_overload<void(float)>(&rive::Mat2D::xx))
-      .property("xy", select_overload<float() const>(&rive::Mat2D::xy),
-                select_overload<void(float)>(&rive::Mat2D::xy))
-      .property("yx", select_overload<float() const>(&rive::Mat2D::yx),
-                select_overload<void(float)>(&rive::Mat2D::yx))
-      .property("yy", select_overload<float() const>(&rive::Mat2D::yy),
-                select_overload<void(float)>(&rive::Mat2D::yy))
-      .property("tx", select_overload<float() const>(&rive::Mat2D::tx),
-                select_overload<void(float)>(&rive::Mat2D::tx))
-      .property("ty", select_overload<float() const>(&rive::Mat2D::ty),
-                select_overload<void(float)>(&rive::Mat2D::ty))
-      .function("invert", optional_override([](rive::Mat2D &self,
-                                               rive::Mat2D &result) -> bool {
-                  return self.invert(&result);
-                }))
-      .function("multiply",
-                optional_override([](rive::Mat2D &self, rive::Mat2D &result,
-                                     rive::Mat2D &other) -> void {
-                  result = rive::Mat2D::multiply(self, other);
-                }));
+    class_<rive::Mat2D>("Mat2D")
+        .constructor<>()
+        .property("xx",
+                  select_overload<float() const>(&rive::Mat2D::xx),
+                  select_overload<void(float)>(&rive::Mat2D::xx))
+        .property("xy",
+                  select_overload<float() const>(&rive::Mat2D::xy),
+                  select_overload<void(float)>(&rive::Mat2D::xy))
+        .property("yx",
+                  select_overload<float() const>(&rive::Mat2D::yx),
+                  select_overload<void(float)>(&rive::Mat2D::yx))
+        .property("yy",
+                  select_overload<float() const>(&rive::Mat2D::yy),
+                  select_overload<void(float)>(&rive::Mat2D::yy))
+        .property("tx",
+                  select_overload<float() const>(&rive::Mat2D::tx),
+                  select_overload<void(float)>(&rive::Mat2D::tx))
+        .property("ty",
+                  select_overload<float() const>(&rive::Mat2D::ty),
+                  select_overload<void(float)>(&rive::Mat2D::ty))
+        .function("invert", optional_override([](rive::Mat2D& self, rive::Mat2D& result) -> bool {
+                      return self.invert(&result);
+                  }))
+        .function("multiply",
+                  optional_override([](rive::Mat2D& self, rive::Mat2D& result, rive::Mat2D& other)
+                                        -> void { result = rive::Mat2D::multiply(self, other); }));
 
-  class_<rive::File>("File")
-      .function(
-          "defaultArtboard",
-          optional_override([](rive::File& self) -> rive::ArtboardInstance* {
-            return self.artboardAt(0).release();
-          }),
-          allow_raw_pointers())
-      .function("artboardByName",
-          optional_override([](const rive::File& self, const std::string& name) -> rive::ArtboardInstance* {
-            return self.artboardNamed(name).release();
-          }),
-          allow_raw_pointers())
-      .function("artboardByIndex",
-          optional_override([](const rive::File& self, size_t index) -> rive::ArtboardInstance* {
-            return self.artboardAt(index).release();
-          }),
-          allow_raw_pointers())
-      .function("artboardCount", &rive::File::artboardCount);
+    class_<rive::File>("File")
+        .function("defaultArtboard",
+                  optional_override([](rive::File& self) -> rive::ArtboardInstance* {
+                      return self.artboardAt(0).release();
+                  }),
+                  allow_raw_pointers())
+        .function("artboardByName",
+                  optional_override([](const rive::File& self,
+                                       const std::string& name) -> rive::ArtboardInstance* {
+                      return self.artboardNamed(name).release();
+                  }),
+                  allow_raw_pointers())
+        .function(
+            "artboardByIndex",
+            optional_override([](const rive::File& self, size_t index) -> rive::ArtboardInstance* {
+                return self.artboardAt(index).release();
+            }),
+            allow_raw_pointers())
+        .function("artboardCount", &rive::File::artboardCount);
 
-  class_<rive::Artboard>("ArtboardBase");
-  class_<rive::ArtboardInstance, base<rive::Artboard>>("Artboard")
+    class_<rive::Artboard>("ArtboardBase");
+    class_<rive::ArtboardInstance, base<rive::Artboard>>("Artboard")
 #ifdef ENABLE_QUERY_FLAT_VERTICES
-      .function("flattenPath",
-                optional_override(
-                    [](rive::Artboard &self, size_t index,
-                       bool transformToParent) -> rive::FlattenedPath * {
+        .function("flattenPath",
+                  optional_override([](rive::Artboard& self,
+                                       size_t index,
+                                       bool transformToParent) -> rive::FlattenedPath* {
                       auto artboardObjects = self.objects();
-                      if (index >= artboardObjects.size()) {
-                        return nullptr;
+                      if (index >= artboardObjects.size())
+                      {
+                          return nullptr;
                       }
                       auto object = artboardObjects[index];
-                      if (!object->is<rive::Path>()) {
-                        return nullptr;
+                      if (!object->is<rive::Path>())
+                      {
+                          return nullptr;
                       }
                       auto path = object->as<rive::Path>();
                       return path->makeFlat(transformToParent);
-                    }),
-                allow_raw_pointers())
+                  }),
+                  allow_raw_pointers())
 #endif
-      .property("name", select_overload<const std::string &() const>(
-                            &rive::Artboard::name))
-      .function("advance",
-          optional_override([](rive::ArtboardInstance& self, double seconds) -> bool {
-            return self.advance(seconds);
-        }),
-        allow_raw_pointers())
-      .function(
-          "draw",
-          optional_override([](rive::ArtboardInstance &self, rive::Renderer *renderer) {
-            return self.draw(renderer, rive::Artboard::DrawOption::kNormal);
-          }),
-          allow_raw_pointers())
-      .function("transformComponent",
-                &rive::Artboard::find<rive::TransformComponent>,
-                allow_raw_pointers())
-      .function("node", &rive::Artboard::find<rive::Node>, allow_raw_pointers())
-      .function("bone", &rive::Artboard::find<rive::Bone>, allow_raw_pointers())
-      .function("rootBone", &rive::Artboard::find<rive::RootBone>,
-                allow_raw_pointers())
-      // Animations
-      .function("animationByIndex",
-          optional_override([](rive::ArtboardInstance& self, size_t index) -> rive::LinearAnimation* {
-            return self.animation(index);
-        }),
-        allow_raw_pointers())
-      .function("animationByName",
-          optional_override([](rive::ArtboardInstance& self, const std::string& name) -> rive::LinearAnimation* {
-            return self.animation(name);
-        }),
-        allow_raw_pointers())
-      .function("animationCount",
-          optional_override([](rive::ArtboardInstance& self) -> size_t {
-            return self.animationCount();
-        }))
-      // State machines
-      .function("stateMachineByIndex",
-          optional_override([](rive::ArtboardInstance& self, size_t index) -> rive::StateMachine* {
-            return self.stateMachine(index);
-          }),
-          allow_raw_pointers())
-      .function("stateMachineByName",
-          optional_override([](rive::ArtboardInstance& self, const std::string& name) -> rive::StateMachine* {
-            return self.stateMachine(name);
-          }),
-          allow_raw_pointers())
-      .function("stateMachineCount",
-          optional_override([](rive::ArtboardInstance& self) -> size_t {
-            return self.stateMachineCount();
-        }))
-      .property("bounds",
-          optional_override([](const rive::ArtboardInstance& self) -> rive::AABB {
-            return self.bounds();
-          }))
-      .property("frameOrigin",
-                select_overload<bool() const>(&rive::Artboard::frameOrigin),
-                select_overload<void(bool)>(&rive::Artboard::frameOrigin));
+        .property("name", select_overload<const std::string&() const>(&rive::Artboard::name))
+        .function("advance",
+                  optional_override([](rive::ArtboardInstance& self, double seconds) -> bool {
+                      return self.advance(seconds);
+                  }),
+                  allow_raw_pointers())
+        .function("draw",
+                  optional_override([](rive::ArtboardInstance& self, rive::Renderer* renderer) {
+                      return self.draw(renderer, rive::Artboard::DrawOption::kNormal);
+                  }),
+                  allow_raw_pointers())
+        .function("transformComponent",
+                  &rive::Artboard::find<rive::TransformComponent>,
+                  allow_raw_pointers())
+        .function("node", &rive::Artboard::find<rive::Node>, allow_raw_pointers())
+        .function("bone", &rive::Artboard::find<rive::Bone>, allow_raw_pointers())
+        .function("rootBone", &rive::Artboard::find<rive::RootBone>, allow_raw_pointers())
+        // Animations
+        .function("animationByIndex",
+                  optional_override(
+                      [](rive::ArtboardInstance& self, size_t index) -> rive::LinearAnimation* {
+                          return self.animation(index);
+                      }),
+                  allow_raw_pointers())
+        .function("animationByName",
+                  optional_override([](rive::ArtboardInstance& self, const std::string& name)
+                                        -> rive::LinearAnimation* { return self.animation(name); }),
+                  allow_raw_pointers())
+        .function("animationCount", optional_override([](rive::ArtboardInstance& self) -> size_t {
+                      return self.animationCount();
+                  }))
+        // State machines
+        .function("stateMachineByIndex",
+                  optional_override(
+                      [](rive::ArtboardInstance& self, size_t index) -> rive::StateMachine* {
+                          return self.stateMachine(index);
+                      }),
+                  allow_raw_pointers())
+        .function("stateMachineByName",
+                  optional_override([](rive::ArtboardInstance& self, const std::string& name)
+                                        -> rive::StateMachine* { return self.stateMachine(name); }),
+                  allow_raw_pointers())
+        .function("stateMachineCount",
+                  optional_override([](rive::ArtboardInstance& self) -> size_t {
+                      return self.stateMachineCount();
+                  }))
+        .property("bounds", optional_override([](const rive::ArtboardInstance& self) -> rive::AABB {
+                      return self.bounds();
+                  }))
+        .property("frameOrigin",
+                  select_overload<bool() const>(&rive::Artboard::frameOrigin),
+                  select_overload<void(bool)>(&rive::Artboard::frameOrigin));
 
-  class_<rive::TransformComponent>("TransformComponent")
-      .property(
-          "scaleX",
-          select_overload<float() const>(&rive::TransformComponent::scaleX),
-          select_overload<void(float)>(&rive::TransformComponent::scaleX))
-      .property(
-          "scaleY",
-          select_overload<float() const>(&rive::TransformComponent::scaleY),
-          select_overload<void(float)>(&rive::TransformComponent::scaleY))
-      .property(
-          "rotation",
-          select_overload<float() const>(&rive::TransformComponent::rotation),
-          select_overload<void(float)>(&rive::TransformComponent::rotation))
-      .function("worldTransform",
-                optional_override(
-                    [](rive::TransformComponent &self) -> rive::Mat2D & {
+    class_<rive::TransformComponent>("TransformComponent")
+        .property("scaleX",
+                  select_overload<float() const>(&rive::TransformComponent::scaleX),
+                  select_overload<void(float)>(&rive::TransformComponent::scaleX))
+        .property("scaleY",
+                  select_overload<float() const>(&rive::TransformComponent::scaleY),
+                  select_overload<void(float)>(&rive::TransformComponent::scaleY))
+        .property("rotation",
+                  select_overload<float() const>(&rive::TransformComponent::rotation),
+                  select_overload<void(float)>(&rive::TransformComponent::rotation))
+        .function("worldTransform",
+                  optional_override([](rive::TransformComponent& self) -> rive::Mat2D& {
                       return self.mutableWorldTransform();
-                    }),
-                allow_raw_pointers())
-      .function("parentWorldTransform",
-                optional_override([](rive::TransformComponent &self,
-                                     rive::Mat2D &result) -> void {
-                  result = rive::Mat2D(getParentWorld(self));
-                }),
-                allow_raw_pointers());
+                  }),
+                  allow_raw_pointers())
+        .function(
+            "parentWorldTransform",
+            optional_override([](rive::TransformComponent& self, rive::Mat2D& result) -> void {
+                result = rive::Mat2D(getParentWorld(self));
+            }),
+            allow_raw_pointers());
 
-  class_<rive::Node, base<rive::TransformComponent>>("Node")
-      .property("x",
-                select_overload<float() const>(&rive::TransformComponent::x),
-                select_overload<void(float)>(&rive::Node::x))
-      .property("y",
-                select_overload<float() const>(&rive::TransformComponent::y),
-                select_overload<void(float)>(&rive::Node::y));
+    class_<rive::Node, base<rive::TransformComponent>>("Node")
+        .property("x",
+                  select_overload<float() const>(&rive::TransformComponent::x),
+                  select_overload<void(float)>(&rive::Node::x))
+        .property("y",
+                  select_overload<float() const>(&rive::TransformComponent::y),
+                  select_overload<void(float)>(&rive::Node::y));
 
-  class_<rive::Bone, base<rive::TransformComponent>>("Bone").property(
-      "length", select_overload<float() const>(&rive::Bone::length),
-      select_overload<void(float)>(&rive::Bone::length));
+    class_<rive::Bone, base<rive::TransformComponent>>("Bone").property(
+        "length",
+        select_overload<float() const>(&rive::Bone::length),
+        select_overload<void(float)>(&rive::Bone::length));
 
-  class_<rive::RootBone, base<rive::Bone>>("RootBone")
-      .property("x",
-                select_overload<float() const>(&rive::TransformComponent::x),
-                select_overload<void(float)>(&rive::RootBone::x))
-      .property("y",
-                select_overload<float() const>(&rive::TransformComponent::y),
-                select_overload<void(float)>(&rive::RootBone::y));
+    class_<rive::RootBone, base<rive::Bone>>("RootBone")
+        .property("x",
+                  select_overload<float() const>(&rive::TransformComponent::x),
+                  select_overload<void(float)>(&rive::RootBone::x))
+        .property("y",
+                  select_overload<float() const>(&rive::TransformComponent::y),
+                  select_overload<void(float)>(&rive::RootBone::y));
 
-  class_<rive::Animation>("Animation")
-      .property("name", select_overload<const std::string &() const>(
-                            &rive::AnimationBase::name));
+    class_<rive::Animation>("Animation")
+        .property("name", select_overload<const std::string&() const>(&rive::AnimationBase::name));
 
-  class_<rive::LinearAnimation, base<rive::Animation>>("LinearAnimation")
-      .property("name", select_overload<const std::string &() const>(
-                            &rive::AnimationBase::name))
-      .property("duration", select_overload<uint32_t() const>(
-                                &rive::LinearAnimationBase::duration))
-      .property("fps",
-                select_overload<uint32_t() const>(&rive::LinearAnimationBase::fps))
-      .property("workStart", select_overload<uint32_t() const>(
-                                 &rive::LinearAnimationBase::workStart))
-      .property("workEnd", select_overload<uint32_t() const>(
-                               &rive::LinearAnimationBase::workEnd))
-      .property("enableWorkArea",
-                select_overload<bool() const>(
-                    &rive::LinearAnimationBase::enableWorkArea))
-      .property("loopValue", select_overload<uint32_t() const>(
-                                 &rive::LinearAnimationBase::loopValue))
-      .property("speed", select_overload<float() const>(
-                             &rive::LinearAnimationBase::speed))
-      .function("apply", &rive::LinearAnimation::apply, allow_raw_pointers());
+    class_<rive::LinearAnimation, base<rive::Animation>>("LinearAnimation")
+        .property("name", select_overload<const std::string&() const>(&rive::AnimationBase::name))
+        .property("duration",
+                  select_overload<uint32_t() const>(&rive::LinearAnimationBase::duration))
+        .property("fps", select_overload<uint32_t() const>(&rive::LinearAnimationBase::fps))
+        .property("workStart",
+                  select_overload<uint32_t() const>(&rive::LinearAnimationBase::workStart))
+        .property("workEnd", select_overload<uint32_t() const>(&rive::LinearAnimationBase::workEnd))
+        .property("enableWorkArea",
+                  select_overload<bool() const>(&rive::LinearAnimationBase::enableWorkArea))
+        .property("loopValue",
+                  select_overload<uint32_t() const>(&rive::LinearAnimationBase::loopValue))
+        .property("speed", select_overload<float() const>(&rive::LinearAnimationBase::speed))
+        .function("apply", &rive::LinearAnimation::apply, allow_raw_pointers());
 
-  class_<rive::LinearAnimationInstance>("LinearAnimationInstance")
-      .constructor<rive::LinearAnimation *, rive::ArtboardInstance*>()
-      .property(
-          "time",
-          select_overload<float() const>(&rive::LinearAnimationInstance::time),
-          select_overload<void(float)>(&rive::LinearAnimationInstance::time))
-      .property("didLoop", &rive::LinearAnimationInstance::didLoop)
-      .function("advance", &rive::LinearAnimationInstance::advance)
-      .function("apply", &rive::LinearAnimationInstance::apply,
-                allow_raw_pointers());
+    class_<rive::LinearAnimationInstance>("LinearAnimationInstance")
+        .constructor<rive::LinearAnimation*, rive::ArtboardInstance*>()
+        .property("time",
+                  select_overload<float() const>(&rive::LinearAnimationInstance::time),
+                  select_overload<void(float)>(&rive::LinearAnimationInstance::time))
+        .property("didLoop", &rive::LinearAnimationInstance::didLoop)
+        .function("advance", &rive::LinearAnimationInstance::advance)
+        .function("apply", &rive::LinearAnimationInstance::apply, allow_raw_pointers());
 
-  class_<rive::StateMachine, base<rive::Animation>>("StateMachine");
+    class_<rive::StateMachine, base<rive::Animation>>("StateMachine");
 
-  class_<rive::StateMachineInstance>("StateMachineInstance")
-      .constructor<rive::StateMachine *, rive::ArtboardInstance*>()
-      .function("advance", &rive::StateMachineInstance::advance,
-                allow_raw_pointers())
-      .function("inputCount", &rive::StateMachineInstance::inputCount)
-      .function("input", &rive::StateMachineInstance::input,
-                allow_raw_pointers())
-      .function("pointerDown",
-          optional_override([](rive::StateMachineInstance& self,
-                               double x, double y) {
-            self.pointerDown(rive::Vec2D((float)x, (float)y));
-          }))
-      .function("pointerMove",
-          optional_override([](rive::StateMachineInstance& self,
-                               double x, double y) {
-            self.pointerMove(rive::Vec2D((float)x, (float)y));
-          }))
-      .function("pointerUp",
-          optional_override([](rive::StateMachineInstance& self,
-                               double x, double y) {
-            self.pointerUp(rive::Vec2D((float)x, (float)y));
-          }))
-      .function("stateChangedCount",
-                &rive::StateMachineInstance::stateChangedCount)
-      .function(
-          "stateChangedNameByIndex",
-          optional_override([](rive::StateMachineInstance &self,
-                               size_t index) -> std::string {
-            const rive::LayerState *state = self.stateChangedByIndex(index);
-            if (state != nullptr)
-              switch (state->coreType()) {
-              case rive::AnimationState::typeKey:
-                return state->as<rive::AnimationState>()->animation()->name();
-              case rive::EntryState::typeKey:
-                return "entry";
-              case rive::ExitState::typeKey:
-                return "exit";
-              case rive::AnyState::typeKey:
-                return "any";
-              }
-            return "unknown";
-          }),
-          allow_raw_pointers());
+    class_<rive::StateMachineInstance>("StateMachineInstance")
+        .constructor<rive::StateMachine*, rive::ArtboardInstance*>()
+        .function("advance", &rive::StateMachineInstance::advance, allow_raw_pointers())
+        .function("inputCount", &rive::StateMachineInstance::inputCount)
+        .function("input", &rive::StateMachineInstance::input, allow_raw_pointers())
+        .function("pointerDown",
+                  optional_override([](rive::StateMachineInstance& self, double x, double y) {
+                      self.pointerDown(rive::Vec2D((float)x, (float)y));
+                  }))
+        .function("pointerMove",
+                  optional_override([](rive::StateMachineInstance& self, double x, double y) {
+                      self.pointerMove(rive::Vec2D((float)x, (float)y));
+                  }))
+        .function("pointerUp",
+                  optional_override([](rive::StateMachineInstance& self, double x, double y) {
+                      self.pointerUp(rive::Vec2D((float)x, (float)y));
+                  }))
+        .function("stateChangedCount", &rive::StateMachineInstance::stateChangedCount)
+        .function(
+            "stateChangedNameByIndex",
+            optional_override([](rive::StateMachineInstance& self, size_t index) -> std::string {
+                const rive::LayerState* state = self.stateChangedByIndex(index);
+                if (state != nullptr)
+                    switch (state->coreType())
+                    {
+                        case rive::AnimationState::typeKey:
+                            return state->as<rive::AnimationState>()->animation()->name();
+                        case rive::EntryState::typeKey:
+                            return "entry";
+                        case rive::ExitState::typeKey:
+                            return "exit";
+                        case rive::AnyState::typeKey:
+                            return "any";
+                    }
+                return "unknown";
+            }),
+            allow_raw_pointers());
 
-  class_<rive::SMIInput>("SMIInput")
-      .property("type", &rive::SMIInput::inputCoreType)
-      .property("name", &rive::SMIInput::name)
-      .class_property("bool", &stateMachineBoolTypeKey)
-      .class_property("number", &stateMachineNumberTypeKey)
-      .class_property("trigger", &stateMachineTriggerTypeKey)
-      .function("asBool",
-                optional_override([](rive::SMIInput &self) -> rive::SMIBool * {
-                  if (self.inputCoreType() != stateMachineBoolTypeKey) {
-                    return nullptr;
-                  }
-                  return static_cast<rive::SMIBool *>(&self);
-                }),
-                allow_raw_pointers())
-      .function(
-          "asNumber",
-          optional_override([](rive::SMIInput &self) -> rive::SMINumber * {
-            if (self.inputCoreType() != stateMachineNumberTypeKey) {
-              return nullptr;
-            }
-            return static_cast<rive::SMINumber *>(&self);
-          }),
-          allow_raw_pointers())
-      .function(
-          "asTrigger",
-          optional_override([](rive::SMIInput &self) -> rive::SMITrigger * {
-            if (self.inputCoreType() != stateMachineTriggerTypeKey) {
-              return nullptr;
-            }
-            return static_cast<rive::SMITrigger *>(&self);
-          }),
-          allow_raw_pointers());
+    class_<rive::SMIInput>("SMIInput")
+        .property("type", &rive::SMIInput::inputCoreType)
+        .property("name", &rive::SMIInput::name)
+        .class_property("bool", &stateMachineBoolTypeKey)
+        .class_property("number", &stateMachineNumberTypeKey)
+        .class_property("trigger", &stateMachineTriggerTypeKey)
+        .function("asBool",
+                  optional_override([](rive::SMIInput& self) -> rive::SMIBool* {
+                      if (self.inputCoreType() != stateMachineBoolTypeKey)
+                      {
+                          return nullptr;
+                      }
+                      return static_cast<rive::SMIBool*>(&self);
+                  }),
+                  allow_raw_pointers())
+        .function("asNumber",
+                  optional_override([](rive::SMIInput& self) -> rive::SMINumber* {
+                      if (self.inputCoreType() != stateMachineNumberTypeKey)
+                      {
+                          return nullptr;
+                      }
+                      return static_cast<rive::SMINumber*>(&self);
+                  }),
+                  allow_raw_pointers())
+        .function("asTrigger",
+                  optional_override([](rive::SMIInput& self) -> rive::SMITrigger* {
+                      if (self.inputCoreType() != stateMachineTriggerTypeKey)
+                      {
+                          return nullptr;
+                      }
+                      return static_cast<rive::SMITrigger*>(&self);
+                  }),
+                  allow_raw_pointers());
 
-  class_<rive::SMIBool, base<rive::SMIInput>>("SMIBool").property(
-      "value", select_overload<bool() const>(&rive::SMIBool::value),
-      select_overload<void(bool)>(&rive::SMIBool::value));
-  class_<rive::SMINumber, base<rive::SMIInput>>("SMINumber")
-      .property("value",
-                select_overload<float() const>(&rive::SMINumber::value),
-                select_overload<void(float)>(&rive::SMINumber::value));
-  class_<rive::SMITrigger, base<rive::SMIInput>>("SMITrigger")
-      .function("fire", &rive::SMITrigger::fire);
+    class_<rive::SMIBool, base<rive::SMIInput>>("SMIBool").property(
+        "value",
+        select_overload<bool() const>(&rive::SMIBool::value),
+        select_overload<void(bool)>(&rive::SMIBool::value));
+    class_<rive::SMINumber, base<rive::SMIInput>>("SMINumber")
+        .property("value",
+                  select_overload<float() const>(&rive::SMINumber::value),
+                  select_overload<void(float)>(&rive::SMINumber::value));
+    class_<rive::SMITrigger, base<rive::SMIInput>>("SMITrigger")
+        .function("fire", &rive::SMITrigger::fire);
 
-  enum_<rive::Fit>("Fit")
-      .value("fill", rive::Fit::fill)
-      .value("contain", rive::Fit::contain)
-      .value("cover", rive::Fit::cover)
-      .value("fitWidth", rive::Fit::fitWidth)
-      .value("fitHeight", rive::Fit::fitHeight)
-      .value("none", rive::Fit::none)
-      .value("scaleDown", rive::Fit::scaleDown);
+    enum_<rive::Fit>("Fit")
+        .value("fill", rive::Fit::fill)
+        .value("contain", rive::Fit::contain)
+        .value("cover", rive::Fit::cover)
+        .value("fitWidth", rive::Fit::fitWidth)
+        .value("fitHeight", rive::Fit::fitHeight)
+        .value("none", rive::Fit::none)
+        .value("scaleDown", rive::Fit::scaleDown);
 
-  class_<rive::Alignment>("Alignment")
-      .property("x", &rive::Alignment::x)
-      .property("y", &rive::Alignment::y)
-      .class_property("topLeft", &rive::Alignment::topLeft)
-      .class_property("topCenter", &rive::Alignment::topCenter)
-      .class_property("topRight", &rive::Alignment::topRight)
-      .class_property("centerLeft", &rive::Alignment::centerLeft)
-      .class_property("center", &rive::Alignment::center)
-      .class_property("centerRight", &rive::Alignment::centerRight)
-      .class_property("bottomLeft", &rive::Alignment::bottomLeft)
-      .class_property("bottomCenter", &rive::Alignment::bottomCenter)
-      .class_property("bottomRight", &rive::Alignment::bottomRight);
+    enum_<JsAlignment>("Alignment")
+        .value("topLeft", JsAlignment::topLeft)
+        .value("topCenter", JsAlignment::topCenter)
+        .value("topRight", JsAlignment::topRight)
+        .value("centerLeft", JsAlignment::centerLeft)
+        .value("center", JsAlignment::center)
+        .value("centerRight", JsAlignment::centerRight)
+        .value("bottomLeft", JsAlignment::bottomLeft)
+        .value("bottomCenter", JsAlignment::bottomCenter)
+        .value("bottomRight", JsAlignment::bottomRight);
 
-  value_object<rive::AABB>("AABB")
-      .field("minX", &rive::AABB::minX)
-      .field("minY", &rive::AABB::minY)
-      .field("maxX", &rive::AABB::maxX)
-      .field("maxY", &rive::AABB::maxY);
+    value_object<rive::AABB>("AABB")
+        .field("minX", &rive::AABB::minX)
+        .field("minY", &rive::AABB::minY)
+        .field("maxX", &rive::AABB::maxX)
+        .field("maxY", &rive::AABB::maxY);
 
-  class_<DynamicRectanizer>("DynamicRectanizer")
-      .constructor<int>()
-      .function("reset", &DynamicRectanizer::reset)
-      .function("addRect", &DynamicRectanizer::addRect)
-      .function("drawWidth", &DynamicRectanizer::drawWidth)
-      .function("drawHeight", &DynamicRectanizer::drawHeight);
+    class_<DynamicRectanizer>("DynamicRectanizer")
+        .constructor<int>()
+        .function("reset", &DynamicRectanizer::reset)
+        .function("addRect", &DynamicRectanizer::addRect)
+        .function("drawWidth", &DynamicRectanizer::drawWidth)
+        .function("drawHeight", &DynamicRectanizer::drawHeight);
+
+#ifdef DEBUG
+    function("doLeakCheck", &__lsan_do_recoverable_leak_check);
+#endif
 }

--- a/wasm/src/bindings_c2d.cpp
+++ b/wasm/src/bindings_c2d.cpp
@@ -8,6 +8,7 @@
 #include "utils/factory_utils.hpp"
 
 #include "skia_imports/include/private/SkVx.h"
+#include "js_alignment.hpp"
 
 #include <emscripten.h>
 #include <emscripten/bind.h>
@@ -20,410 +21,444 @@
 using namespace emscripten;
 
 // Computes the post-transform bounding box of an array of points in high performance WASM SIMD.
-static std::array<float, 4> bbox(const float m[6], const float* vertexData, int numVertexFloats) {
-  using float2 = skvx::Vec<2, float>;
-  using float4 = skvx::Vec<4, float>;
+static std::array<float, 4> bbox(const float m[6], const float* vertexData, int numVertexFloats)
+{
+    using float2 = skvx::Vec<2, float>;
+    using float4 = skvx::Vec<4, float>;
 
-  assert(numVertexFloats > 0);
-  assert(numVertexFloats % 2 == 0);  // numVertexFloats must be even -- 2 floats per vertex.
+    assert(numVertexFloats > 0);
+    assert(numVertexFloats % 2 == 0); // numVertexFloats must be even -- 2 floats per vertex.
 
-  float4 scale = {m[0], m[3], m[0], m[3]};
-  float4 skew = {m[2], m[1], m[2], m[1]};
-  float2 translate = {m[4], m[5]};
+    float4 scale = {m[0], m[3], m[0], m[3]};
+    float4 skew = {m[2], m[1], m[2], m[1]};
+    float2 translate = {m[4], m[5]};
 
-  // Compute two partial bounding boxes in parallel lanes of float4. Defer the translation until
-  // after min/max reduction.
-  float4 partialTopLefts, partialBotRights;
-  float4 v0;
-  int i;
-  // TODO: could 128-bit alignment on loads impact our speed in WASM?
-  if (!(numVertexFloats & 3)) {
-    // Even number of vertices -- number of floats is divisible by 4. Load 2 vertices initially.
-    v0 = float4::Load(vertexData);
-    i = 4;
-  } else {
-    // Odd number of vertices. Load 1 vertex initially so the rest will be divisible by 4.
-    v0 = float2::Load(vertexData).xyxy();
-    i = 2;
-  }
-  partialTopLefts = partialBotRights = v0 * scale + v0.yxwz() * skew;
-  // Crunch the remaining vertices in float4 SIMD.
-  for (; i < numVertexFloats; i += 4) {
-    float4 v = float4::Load(vertexData + i);
-    v = v * scale + v.yxwz() * skew;
-    partialTopLefts = min(partialTopLefts, v);
-    partialBotRights = max(partialBotRights, v);
-  }
-  assert(i == numVertexFloats);
+    // Compute two partial bounding boxes in parallel lanes of float4. Defer the translation until
+    // after min/max reduction.
+    float4 partialTopLefts, partialBotRights;
+    float4 v0;
+    int i;
+    // TODO: could 128-bit alignment on loads impact our speed in WASM?
+    if (!(numVertexFloats & 3))
+    {
+        // Even number of vertices -- number of floats is divisible by 4. Load 2 vertices initially.
+        v0 = float4::Load(vertexData);
+        i = 4;
+    }
+    else
+    {
+        // Odd number of vertices. Load 1 vertex initially so the rest will be divisible by 4.
+        v0 = float2::Load(vertexData).xyxy();
+        i = 2;
+    }
+    partialTopLefts = partialBotRights = v0 * scale + v0.yxwz() * skew;
+    // Crunch the remaining vertices in float4 SIMD.
+    for (; i < numVertexFloats; i += 4)
+    {
+        float4 v = float4::Load(vertexData + i);
+        v = v * scale + v.yxwz() * skew;
+        partialTopLefts = min(partialTopLefts, v);
+        partialBotRights = max(partialBotRights, v);
+    }
+    assert(i == numVertexFloats);
 
-  // Merge the two parallel bounding boxes into one complete, translated, integer bounding box.
-  float2 topLeft = floor(min(partialTopLefts.lo, partialTopLefts.hi) + translate);
-  float2 botRight = ceil(max(partialBotRights.lo, partialBotRights.hi) + translate);
-  return {topLeft.x(), topLeft.y(), botRight.x(), botRight.y()};
+    // Merge the two parallel bounding boxes into one complete, translated, integer bounding box.
+    float2 topLeft = floor(min(partialTopLefts.lo, partialTopLefts.hi) + translate);
+    float2 botRight = ceil(max(partialBotRights.lo, partialBotRights.hi) + translate);
+    return {topLeft.x(), topLeft.y(), botRight.x(), botRight.y()};
 }
 
-class RendererWrapper : public wrapper<rive::Renderer> {
+class RendererWrapper : public wrapper<rive::Renderer>
+{
 public:
-  EMSCRIPTEN_WRAPPER(RendererWrapper);
+    EMSCRIPTEN_WRAPPER(RendererWrapper);
 
-  void save() override { call<void>("save"); }
+    void save() override { call<void>("save"); }
 
-  void restore() override { call<void>("restore"); }
+    void restore() override { call<void>("restore"); }
 
-  void transform(const rive::Mat2D &transform) override {
-    call<void>("transform", transform);
-  }
+    void transform(const rive::Mat2D& transform) override { call<void>("transform", transform); }
 
-  void drawPath(rive::RenderPath *path, rive::RenderPaint *paint) override {
-    call<void>("_drawPath", path, paint);
-  }
-
-  void clipPath(rive::RenderPath *path) override {
-    call<void>("_clipPath", path);
-  }
-
-  void drawImage(const rive::RenderImage *image, rive::BlendMode value,
-                 float opacity) override {
-    call<void>("_drawImage", image, value, opacity);
-  }
-
-  void drawImageMesh(const rive::RenderImage *image,
-                     rive::rcp<rive::RenderBuffer> vertices_f32,
-                     rive::rcp<rive::RenderBuffer> uvCoords_f32,
-                     rive::rcp<rive::RenderBuffer> indices_u16,
-                     rive::BlendMode value, float opacity) override {
-
-    auto vtx = rive::DataRenderBuffer::Cast(vertices_f32.get());
-    auto uv = rive::DataRenderBuffer::Cast(uvCoords_f32.get());
-    auto indices = rive::DataRenderBuffer::Cast(indices_u16.get());
-
-    assert(uv->count() == vtx->count());
-    if (!vtx->count() || !indices->count()) {
-        return;
+    void drawPath(rive::RenderPath* path, rive::RenderPaint* paint) override
+    {
+        call<void>("_drawPath", path, paint);
     }
 
-    emscripten::val uvJS{emscripten::typed_memory_view(uv->count(), uv->f32s())};
-    emscripten::val vtxJS{emscripten::typed_memory_view(vtx->count(), vtx->f32s())};
-    emscripten::val indicesJS{emscripten::typed_memory_view(indices->count(), indices->u16s())};
+    void clipPath(rive::RenderPath* path) override { call<void>("_clipPath", path); }
 
-    // Compute the mesh's bounding box.
-    float m[6];
-    emscripten::val mJS{emscripten::typed_memory_view(6, m)};
-    call<void>("_getMatrix", mJS);
-    auto [l, t, r, b] = bbox(m, vtx->f32s(), vtx->count());
+    void drawImage(const rive::RenderImage* image, rive::BlendMode value, float opacity) override
+    {
+        call<void>("_drawImage", image, value, opacity);
+    }
 
-    call<void>("_drawImageMesh", image, value, opacity, vtxJS, uvJS, indicesJS, l, t, r, b);
-  }
+    void drawImageMesh(const rive::RenderImage* image,
+                       rive::rcp<rive::RenderBuffer> vertices_f32,
+                       rive::rcp<rive::RenderBuffer> uvCoords_f32,
+                       rive::rcp<rive::RenderBuffer> indices_u16,
+                       rive::BlendMode value,
+                       float opacity) override
+    {
+
+        auto vtx = rive::DataRenderBuffer::Cast(vertices_f32.get());
+        auto uv = rive::DataRenderBuffer::Cast(uvCoords_f32.get());
+        auto indices = rive::DataRenderBuffer::Cast(indices_u16.get());
+
+        assert(uv->count() == vtx->count());
+        if (!vtx->count() || !indices->count())
+        {
+            return;
+        }
+
+        emscripten::val uvJS{emscripten::typed_memory_view(uv->count(), uv->f32s())};
+        emscripten::val vtxJS{emscripten::typed_memory_view(vtx->count(), vtx->f32s())};
+        emscripten::val indicesJS{emscripten::typed_memory_view(indices->count(), indices->u16s())};
+
+        // Compute the mesh's bounding box.
+        float m[6];
+        emscripten::val mJS{emscripten::typed_memory_view(6, m)};
+        call<void>("_getMatrix", mJS);
+        auto [l, t, r, b] = bbox(m, vtx->f32s(), vtx->count());
+
+        call<void>("_drawImageMesh", image, value, opacity, vtxJS, uvJS, indicesJS, l, t, r, b);
+    }
 };
 
-class RenderPathWrapper : public wrapper<rive::RenderPath> {
+class RenderPathWrapper : public wrapper<rive::RenderPath>
+{
 public:
-  EMSCRIPTEN_WRAPPER(RenderPathWrapper);
+    EMSCRIPTEN_WRAPPER(RenderPathWrapper);
 
-  void reset() override { call<void>("reset"); }
+    void reset() override { call<void>("reset"); }
 
-  void addRenderPath(rive::RenderPath *path,
-                     const rive::Mat2D &transform) override {
-    call<void>("addPath", path, transform);
-  }
-  void fillRule(rive::FillRule value) override {
-    call<void>("fillRule", value);
-  }
+    void addRenderPath(rive::RenderPath* path, const rive::Mat2D& transform) override
+    {
+        call<void>("addPath", path, transform);
+    }
+    void fillRule(rive::FillRule value) override { call<void>("fillRule", value); }
 
-  void moveTo(float x, float y) override { call<void>("moveTo", x, y); }
-  void lineTo(float x, float y) override { call<void>("lineTo", x, y); }
-  void cubicTo(float ox, float oy, float ix, float iy, float x,
-               float y) override {
-    call<void>("cubicTo", ox, oy, ix, iy, x, y);
-  }
-  void close() override { call<void>("close"); }
+    void moveTo(float x, float y) override { call<void>("moveTo", x, y); }
+    void lineTo(float x, float y) override { call<void>("lineTo", x, y); }
+    void cubicTo(float ox, float oy, float ix, float iy, float x, float y) override
+    {
+        call<void>("cubicTo", ox, oy, ix, iy, x, y);
+    }
+    void close() override { call<void>("close"); }
 };
 
 class RenderPaintWrapper;
-class GradientShader : public rive::RenderShader {
+class GradientShader : public rive::RenderShader
+{
 private:
-  std::vector<float> m_Stops;
-  std::vector<rive::ColorInt> m_Colors;
+    std::vector<float> m_Stops;
+    std::vector<rive::ColorInt> m_Colors;
 
 public:
-  GradientShader(const rive::ColorInt colors[], const float stops[], int count)
-      : m_Stops(stops, stops + count), m_Colors(colors, colors + count) {}
+    GradientShader(const rive::ColorInt colors[], const float stops[], int count) :
+        m_Stops(stops, stops + count), m_Colors(colors, colors + count)
+    {}
 
-  void passStopsToJS(const RenderPaintWrapper &wrapper);
+    void passStopsToJS(const RenderPaintWrapper& wrapper);
 
-  virtual void passToJS(const RenderPaintWrapper &wrapper) = 0;
+    virtual void passToJS(const RenderPaintWrapper& wrapper) = 0;
 };
 
-class LinearGradientShader : public GradientShader {
+class LinearGradientShader : public GradientShader
+{
 private:
-  float m_StartX;
-  float m_StartY;
-  float m_EndX;
-  float m_EndY;
+    float m_StartX;
+    float m_StartY;
+    float m_EndX;
+    float m_EndY;
 
 public:
-  LinearGradientShader(const rive::ColorInt colors[], const float stops[],
-                       int count, float sx, float sy, float ex, float ey)
-      : GradientShader(colors, stops, count), m_StartX(sx), m_StartY(sy),
-        m_EndX(ex), m_EndY(ey) {}
+    LinearGradientShader(const rive::ColorInt colors[],
+                         const float stops[],
+                         int count,
+                         float sx,
+                         float sy,
+                         float ex,
+                         float ey) :
+        GradientShader(colors, stops, count), m_StartX(sx), m_StartY(sy), m_EndX(ex), m_EndY(ey)
+    {}
 
-  void passToJS(const RenderPaintWrapper &wrapper) override;
+    void passToJS(const RenderPaintWrapper& wrapper) override;
 };
 
-class RadialGradientShader : public GradientShader {
+class RadialGradientShader : public GradientShader
+{
 private:
-  float m_CenterX;
-  float m_CenterY;
-  float m_Radius;
+    float m_CenterX;
+    float m_CenterY;
+    float m_Radius;
 
 public:
-  RadialGradientShader(const rive::ColorInt colors[], const float stops[],
-                       int count, float cx, float cy, float r)
-      : GradientShader(colors, stops, count), m_CenterX(cx), m_CenterY(cy),
-        m_Radius(r) {}
+    RadialGradientShader(const rive::ColorInt colors[],
+                         const float stops[],
+                         int count,
+                         float cx,
+                         float cy,
+                         float r) :
+        GradientShader(colors, stops, count), m_CenterX(cx), m_CenterY(cy), m_Radius(r)
+    {}
 
-  void passToJS(const RenderPaintWrapper &wrapper) override;
+    void passToJS(const RenderPaintWrapper& wrapper) override;
 };
 
-class RenderPaintWrapper : public wrapper<rive::RenderPaint> {
+class RenderPaintWrapper : public wrapper<rive::RenderPaint>
+{
 public:
-  EMSCRIPTEN_WRAPPER(RenderPaintWrapper);
+    EMSCRIPTEN_WRAPPER(RenderPaintWrapper);
 
-  void color(unsigned int value) override { call<void>("color", value); }
-  void thickness(float value) override { call<void>("thickness", value); }
-  void join(rive::StrokeJoin value) override { call<void>("join", value); }
-  void cap(rive::StrokeCap value) override { call<void>("cap", value); }
-  void blendMode(rive::BlendMode value) override {
-    call<void>("blendMode", value);
-  }
+    void color(unsigned int value) override { call<void>("color", value); }
+    void thickness(float value) override { call<void>("thickness", value); }
+    void join(rive::StrokeJoin value) override { call<void>("join", value); }
+    void cap(rive::StrokeCap value) override { call<void>("cap", value); }
+    void blendMode(rive::BlendMode value) override { call<void>("blendMode", value); }
 
-  void style(rive::RenderPaintStyle value) override {
-    call<void>("style", value);
-  }
+    void style(rive::RenderPaintStyle value) override { call<void>("style", value); }
 
-  void shader(rive::rcp<rive::RenderShader> shader) override {
-    static_cast<GradientShader *>(shader.get())->passToJS(*this);
-  }
-  void invalidateStroke() override {}
+    void shader(rive::rcp<rive::RenderShader> shader) override
+    {
+        static_cast<GradientShader*>(shader.get())->passToJS(*this);
+    }
+    void invalidateStroke() override {}
 };
 
-void GradientShader::passStopsToJS(const RenderPaintWrapper &wrapper) {
-  // Consider passing in a bulk op encoding into a single array.
-  for (std::size_t i = 0; i < m_Stops.size(); i++) {
-    wrapper.call<void>("addStop", m_Colors[i], m_Stops[i]);
-  }
+void GradientShader::passStopsToJS(const RenderPaintWrapper& wrapper)
+{
+    // Consider passing in a bulk op encoding into a single array.
+    for (std::size_t i = 0; i < m_Stops.size(); i++)
+    {
+        wrapper.call<void>("addStop", m_Colors[i], m_Stops[i]);
+    }
 }
 
-void LinearGradientShader::passToJS(const RenderPaintWrapper &wrapper) {
-  wrapper.call<void>("linearGradient", m_StartX, m_StartY, m_EndX, m_EndY);
-  passStopsToJS(wrapper);
+void LinearGradientShader::passToJS(const RenderPaintWrapper& wrapper)
+{
+    wrapper.call<void>("linearGradient", m_StartX, m_StartY, m_EndX, m_EndY);
+    passStopsToJS(wrapper);
 }
 
-void RadialGradientShader::passToJS(const RenderPaintWrapper &wrapper) {
-  wrapper.call<void>("radialGradient", m_CenterX, m_CenterY,
-                     m_CenterX + m_Radius, m_CenterY);
-  passStopsToJS(wrapper);
+void RadialGradientShader::passToJS(const RenderPaintWrapper& wrapper)
+{
+    wrapper.call<void>("radialGradient", m_CenterX, m_CenterY, m_CenterX + m_Radius, m_CenterY);
+    passStopsToJS(wrapper);
 }
 
-class RenderImageWrapper : public wrapper<rive::RenderImage> {
+class RenderImageWrapper : public wrapper<rive::RenderImage>
+{
 public:
-  EMSCRIPTEN_WRAPPER(RenderImageWrapper);
+    EMSCRIPTEN_WRAPPER(RenderImageWrapper);
 
-  bool decode(rive::Span<const uint8_t> bytes) {
-    emscripten::val byteArray = emscripten::val(
-        emscripten::typed_memory_view(bytes.size(), bytes.data()));
-    return call<bool>("decode", byteArray);
-  }
+    bool decode(rive::Span<const uint8_t> bytes)
+    {
+        emscripten::val byteArray =
+            emscripten::val(emscripten::typed_memory_view(bytes.size(), bytes.data()));
+        return call<bool>("decode", byteArray);
+    }
 
-  void size(int width, int height) {
-    m_Width = width;
-    m_Height = height;
-  }
+    void size(int width, int height)
+    {
+        m_Width = width;
+        m_Height = height;
+    }
 };
 
-namespace rive {
+namespace rive
+{
 
-class C2DFactory : public Factory {
-    rcp<RenderBuffer> makeBufferU16(Span<const uint16_t> data) override {
+class C2DFactory : public Factory
+{
+    rcp<RenderBuffer> makeBufferU16(Span<const uint16_t> data) override
+    {
         return rive::DataRenderBuffer::Make(data);
     }
-    rcp<RenderBuffer> makeBufferU32(Span<const uint32_t> data) override {
+    rcp<RenderBuffer> makeBufferU32(Span<const uint32_t> data) override
+    {
         return rive::DataRenderBuffer::Make(data);
     }
-    rcp<RenderBuffer> makeBufferF32(Span<const float> data) override {
+    rcp<RenderBuffer> makeBufferF32(Span<const float> data) override
+    {
         return rive::DataRenderBuffer::Make(data);
     }
 
-    rcp<RenderShader> makeLinearGradient(float sx, float sy,
-                                         float ex, float ey,
-                                         const ColorInt colors[],    // [count]
-                                         const float stops[],        // [count]
-                                         size_t count) override {
-      return rcp<RenderShader>(
-        new LinearGradientShader(colors, stops, count, sx, sy, ex, ey));
+    rcp<RenderShader> makeLinearGradient(float sx,
+                                         float sy,
+                                         float ex,
+                                         float ey,
+                                         const ColorInt colors[], // [count]
+                                         const float stops[],     // [count]
+                                         size_t count) override
+    {
+        return rcp<RenderShader>(new LinearGradientShader(colors, stops, count, sx, sy, ex, ey));
     }
-    rcp<RenderShader> makeRadialGradient(float cx, float cy, float radius,
-                                         const ColorInt colors[],    // [count]
-                                         const float stops[],        // [count]
-                                         size_t count) override {
-      return rcp<RenderShader>(
-        new RadialGradientShader(colors, stops, count, cx, cy, radius));
+    rcp<RenderShader> makeRadialGradient(float cx,
+                                         float cy,
+                                         float radius,
+                                         const ColorInt colors[], // [count]
+                                         const float stops[],     // [count]
+                                         size_t count) override
+    {
+        return rcp<RenderShader>(new RadialGradientShader(colors, stops, count, cx, cy, radius));
     }
-    
-    std::unique_ptr<RenderPath> makeRenderPath(RawPath& path,
-                                               FillRule fr) override {
-      val renderPath =
-        val::module_property("renderFactory").call<val>("makeRenderPath");
-      auto ptr = renderPath.as<RenderPath *>(allow_raw_pointers());
-      
-      // It might be faster to do this on the JS side, and just pass up the arrays...
-      // for now, we do it one segment at a time (each turns into an up-call to JS)
-      ptr->fillRule(fr);
-      const Vec2D* pts = path.points().data();
-      for (auto v : path.verbs()) {
-        switch ((PathVerb)v) {
-          case PathVerb::move: ptr->move(*pts++); break;
-          case PathVerb::line: ptr->line(*pts++); break;
-          case PathVerb::cubic: ptr->cubic(pts[0], pts[1], pts[2]); pts += 3; break;
-          case PathVerb::close: ptr->close(); break;
-          default: assert(false); // unexpected verb
+
+    std::unique_ptr<RenderPath> makeRenderPath(RawPath& path, FillRule fr) override
+    {
+        val renderPath = val::module_property("renderFactory").call<val>("makeRenderPath");
+        auto ptr = renderPath.as<RenderPath*>(allow_raw_pointers());
+
+        // It might be faster to do this on the JS side, and just pass up the arrays...
+        // for now, we do it one segment at a time (each turns into an up-call to JS)
+        ptr->fillRule(fr);
+        const Vec2D* pts = path.points().data();
+        for (auto v : path.verbs())
+        {
+            switch ((PathVerb)v)
+            {
+                case PathVerb::move:
+                    ptr->move(*pts++);
+                    break;
+                case PathVerb::line:
+                    ptr->line(*pts++);
+                    break;
+                case PathVerb::cubic:
+                    ptr->cubic(pts[0], pts[1], pts[2]);
+                    pts += 3;
+                    break;
+                case PathVerb::close:
+                    ptr->close();
+                    break;
+                default:
+                    assert(false); // unexpected verb
+            }
         }
-      }
-      assert(pts - path.points().data() == path.points().size());
-    
-      return std::unique_ptr<RenderPath>(ptr);
+        assert(pts - path.points().data() == path.points().size());
+
+        return std::unique_ptr<RenderPath>(ptr);
     }
 
-    std::unique_ptr<RenderPath> makeEmptyRenderPath() override {
-      val renderPath =
-        val::module_property("renderFactory").call<val>("makeRenderPath");
-      auto ptr = renderPath.as<RenderPath *>(allow_raw_pointers());
-      return std::unique_ptr<RenderPath>(ptr);
+    std::unique_ptr<RenderPath> makeEmptyRenderPath() override
+    {
+        val renderPath = val::module_property("renderFactory").call<val>("makeRenderPath");
+        auto ptr = renderPath.as<RenderPath*>(allow_raw_pointers());
+        return std::unique_ptr<RenderPath>(ptr);
     }
-  
-    std::unique_ptr<RenderPaint> makeRenderPaint() override {
-      val renderPaint =
-        val::module_property("renderFactory").call<val>("makeRenderPaint");
-      auto ptr = renderPaint.as<RenderPaint *>(allow_raw_pointers());
-      return std::unique_ptr<RenderPaint>(ptr);
-    }
-  
-    std::unique_ptr<RenderImage> decodeImage(Span<const uint8_t> bytes) override {
-      // TODO: seems like we should change the constructor the the JS RenderImage to
-      //       be pased the byteArray, and have it decode (or fail) right away.
-      //       It could just return null to us for its object if it failed.
-      //   ... that would avoid that tricky cast to RenderImageWrapper*
-    
-      val renderImage =
-        val::module_property("renderFactory").call<val>("makeRenderImage");
 
-      auto ptr = renderImage.as<RenderImageWrapper *>(allow_raw_pointers());
-      if (!ptr->decode(bytes)) {
- //       delete ptr;
- //       ptr = nullptr;
-      }
-      return std::unique_ptr<RenderImage>(ptr);
+    std::unique_ptr<RenderPaint> makeRenderPaint() override
+    {
+        val renderPaint = val::module_property("renderFactory").call<val>("makeRenderPaint");
+        auto ptr = renderPaint.as<RenderPaint*>(allow_raw_pointers());
+        return std::unique_ptr<RenderPaint>(ptr);
+    }
+
+    std::unique_ptr<RenderImage> decodeImage(Span<const uint8_t> bytes) override
+    {
+        // TODO: seems like we should change the constructor the the JS RenderImage to
+        //       be pased the byteArray, and have it decode (or fail) right away.
+        //       It could just return null to us for its object if it failed.
+        //   ... that would avoid that tricky cast to RenderImageWrapper*
+
+        val renderImage = val::module_property("renderFactory").call<val>("makeRenderImage");
+
+        auto ptr = renderImage.as<RenderImageWrapper*>(allow_raw_pointers());
+        if (!ptr->decode(bytes))
+        {
+            //       delete ptr;
+            //       ptr = nullptr;
+        }
+        return std::unique_ptr<RenderImage>(ptr);
     }
 };
 
 } // namespace rive
 
-EMSCRIPTEN_BINDINGS(RiveWASM_C2D) {
-  class_<rive::Renderer>("Renderer")
-      .function("save", &RendererWrapper::save, pure_virtual(),
-                allow_raw_pointers())
-      .function("restore", &RendererWrapper::restore, pure_virtual(),
-                allow_raw_pointers())
-      .function("transform", &RendererWrapper::transform, pure_virtual(),
-                allow_raw_pointers())
-      .function("drawPath", &RendererWrapper::drawPath, pure_virtual(),
-                allow_raw_pointers())
-      .function("clipPath", &RendererWrapper::clipPath, pure_virtual(),
-                allow_raw_pointers())
-      .function("align", &rive::Renderer::align)
-      .allow_subclass<RendererWrapper>("RendererWrapper");
+EMSCRIPTEN_BINDINGS(RiveWASM_C2D)
+{
+    class_<rive::Renderer>("Renderer")
+        .function("save", &RendererWrapper::save, pure_virtual(), allow_raw_pointers())
+        .function("restore", &RendererWrapper::restore, pure_virtual(), allow_raw_pointers())
+        .function("transform", &RendererWrapper::transform, pure_virtual(), allow_raw_pointers())
+        .function("drawPath", &RendererWrapper::drawPath, pure_virtual(), allow_raw_pointers())
+        .function("clipPath", &RendererWrapper::clipPath, pure_virtual(), allow_raw_pointers())
+        .function("align",
+                  optional_override([](rive::Renderer& self,
+                                       rive::Fit fit,
+                                       JsAlignment alignment,
+                                       const rive::AABB& frame,
+                                       const rive::AABB& content) {
+                      self.align(fit, convertAlignment(alignment), frame, content);
+                  }))
+        .allow_subclass<RendererWrapper>("RendererWrapper");
 
-  class_<rive::RenderPath>("RenderPath")
-      .function("reset", &RenderPathWrapper::reset, pure_virtual(),
-                allow_raw_pointers())
-      .function("addPath", &RenderPathWrapper::addRenderPath, pure_virtual(),
-                allow_raw_pointers())
-      .function("fillRule", &RenderPathWrapper::fillRule, pure_virtual())
-      .function("moveTo", &RenderPathWrapper::moveTo, pure_virtual(),
-                allow_raw_pointers())
-      .function("lineTo", &RenderPathWrapper::lineTo, pure_virtual(),
-                allow_raw_pointers())
-      .function("cubicTo", &RenderPathWrapper::cubicTo, pure_virtual(),
-                allow_raw_pointers())
-      .function("close", &RenderPathWrapper::close, pure_virtual(),
-                allow_raw_pointers())
-      .allow_subclass<RenderPathWrapper>("RenderPathWrapper");
-  enum_<rive::RenderPaintStyle>("RenderPaintStyle")
-      .value("fill", rive::RenderPaintStyle::fill)
-      .value("stroke", rive::RenderPaintStyle::stroke);
+    class_<rive::RenderPath>("RenderPath")
+        .function("reset", &RenderPathWrapper::reset, pure_virtual(), allow_raw_pointers())
+        .function("addPath",
+                  &RenderPathWrapper::addRenderPath,
+                  pure_virtual(),
+                  allow_raw_pointers())
+        .function("fillRule", &RenderPathWrapper::fillRule, pure_virtual())
+        .function("moveTo", &RenderPathWrapper::moveTo, pure_virtual(), allow_raw_pointers())
+        .function("lineTo", &RenderPathWrapper::lineTo, pure_virtual(), allow_raw_pointers())
+        .function("cubicTo", &RenderPathWrapper::cubicTo, pure_virtual(), allow_raw_pointers())
+        .function("close", &RenderPathWrapper::close, pure_virtual(), allow_raw_pointers())
+        .allow_subclass<RenderPathWrapper>("RenderPathWrapper");
+    enum_<rive::RenderPaintStyle>("RenderPaintStyle")
+        .value("fill", rive::RenderPaintStyle::fill)
+        .value("stroke", rive::RenderPaintStyle::stroke);
 
-  enum_<rive::FillRule>("FillRule")
-      .value("nonZero", rive::FillRule::nonZero)
-      .value("evenOdd", rive::FillRule::evenOdd);
+    enum_<rive::FillRule>("FillRule")
+        .value("nonZero", rive::FillRule::nonZero)
+        .value("evenOdd", rive::FillRule::evenOdd);
 
-  enum_<rive::StrokeCap>("StrokeCap")
-      .value("butt", rive::StrokeCap::butt)
-      .value("round", rive::StrokeCap::round)
-      .value("square", rive::StrokeCap::square);
+    enum_<rive::StrokeCap>("StrokeCap")
+        .value("butt", rive::StrokeCap::butt)
+        .value("round", rive::StrokeCap::round)
+        .value("square", rive::StrokeCap::square);
 
-  enum_<rive::StrokeJoin>("StrokeJoin")
-      .value("miter", rive::StrokeJoin::miter)
-      .value("round", rive::StrokeJoin::round)
-      .value("bevel", rive::StrokeJoin::bevel);
+    enum_<rive::StrokeJoin>("StrokeJoin")
+        .value("miter", rive::StrokeJoin::miter)
+        .value("round", rive::StrokeJoin::round)
+        .value("bevel", rive::StrokeJoin::bevel);
 
-  enum_<rive::BlendMode>("BlendMode")
-      .value("srcOver", rive::BlendMode::srcOver)
-      .value("screen", rive::BlendMode::screen)
-      .value("overlay", rive::BlendMode::overlay)
-      .value("darken", rive::BlendMode::darken)
-      .value("lighten", rive::BlendMode::lighten)
-      .value("colorDodge", rive::BlendMode::colorDodge)
-      .value("colorBurn", rive::BlendMode::colorBurn)
-      .value("hardLight", rive::BlendMode::hardLight)
-      .value("softLight", rive::BlendMode::softLight)
-      .value("difference", rive::BlendMode::difference)
-      .value("exclusion", rive::BlendMode::exclusion)
-      .value("multiply", rive::BlendMode::multiply)
-      .value("hue", rive::BlendMode::hue)
-      .value("saturation", rive::BlendMode::saturation)
-      .value("color", rive::BlendMode::color)
-      .value("luminosity", rive::BlendMode::luminosity);
+    enum_<rive::BlendMode>("BlendMode")
+        .value("srcOver", rive::BlendMode::srcOver)
+        .value("screen", rive::BlendMode::screen)
+        .value("overlay", rive::BlendMode::overlay)
+        .value("darken", rive::BlendMode::darken)
+        .value("lighten", rive::BlendMode::lighten)
+        .value("colorDodge", rive::BlendMode::colorDodge)
+        .value("colorBurn", rive::BlendMode::colorBurn)
+        .value("hardLight", rive::BlendMode::hardLight)
+        .value("softLight", rive::BlendMode::softLight)
+        .value("difference", rive::BlendMode::difference)
+        .value("exclusion", rive::BlendMode::exclusion)
+        .value("multiply", rive::BlendMode::multiply)
+        .value("hue", rive::BlendMode::hue)
+        .value("saturation", rive::BlendMode::saturation)
+        .value("color", rive::BlendMode::color)
+        .value("luminosity", rive::BlendMode::luminosity);
 
-  class_<rive::rcp<rive::RenderShader>>("RenderShader");
+    class_<rive::rcp<rive::RenderShader>>("RenderShader");
 
-  class_<rive::RenderPaint>("RenderPaint")
-      .function("color", &RenderPaintWrapper::color, pure_virtual(),
-                allow_raw_pointers())
+    class_<rive::RenderPaint>("RenderPaint")
+        .function("color", &RenderPaintWrapper::color, pure_virtual(), allow_raw_pointers())
 
-      .function("style", &RenderPaintWrapper::style, pure_virtual(),
-                allow_raw_pointers())
-      .function("thickness", &RenderPaintWrapper::thickness, pure_virtual(),
-                allow_raw_pointers())
-      .function("join", &RenderPaintWrapper::join, pure_virtual(),
-                allow_raw_pointers())
-      .function("cap", &RenderPaintWrapper::cap, pure_virtual(),
-                allow_raw_pointers())
-      .function("blendMode", &RenderPaintWrapper::blendMode, pure_virtual(),
-                allow_raw_pointers())
-      .function("shader", &RenderPaintWrapper::shader, pure_virtual(),
-                allow_raw_pointers())
-      .allow_subclass<RenderPaintWrapper>("RenderPaintWrapper");
+        .function("style", &RenderPaintWrapper::style, pure_virtual(), allow_raw_pointers())
+        .function("thickness", &RenderPaintWrapper::thickness, pure_virtual(), allow_raw_pointers())
+        .function("join", &RenderPaintWrapper::join, pure_virtual(), allow_raw_pointers())
+        .function("cap", &RenderPaintWrapper::cap, pure_virtual(), allow_raw_pointers())
+        .function("blendMode", &RenderPaintWrapper::blendMode, pure_virtual(), allow_raw_pointers())
+        .function("shader", &RenderPaintWrapper::shader, pure_virtual(), allow_raw_pointers())
+        .allow_subclass<RenderPaintWrapper>("RenderPaintWrapper");
 
-  class_<rive::RenderImage>("RenderImage")
-//      .function("decode", &RenderImageWrapper::decode, pure_virtual(), allow_raw_pointers())
-      .function("size", &RenderImageWrapper::size)
-      .allow_subclass<RenderImageWrapper>("RenderImageWrapper");
-
+    class_<rive::RenderImage>("RenderImage")
+        //      .function("decode", &RenderImageWrapper::decode, pure_virtual(),
+        //      allow_raw_pointers())
+        .function("size", &RenderImageWrapper::size)
+        .allow_subclass<RenderImageWrapper>("RenderImageWrapper");
 }
 
 static rive::C2DFactory gC2DFactory;
-rive::Factory* jsFactory() {
-  return &gC2DFactory;
-}
+rive::Factory* jsFactory() { return &gC2DFactory; }
 
 #endif // not RIVE_SKIA_RENDERER

--- a/wasm/src/bindings_skia.cpp
+++ b/wasm/src/bindings_skia.cpp
@@ -20,98 +20,110 @@
 #include <vector>
 
 static rive::SkiaFactory gSkiaFactory;
-rive::Factory* jsFactory() {
-  return &gSkiaFactory;
-}
+rive::Factory* jsFactory() { return &gSkiaFactory; }
 
 using namespace emscripten;
 
-class WebGLSkiaRenderer : public rive::SkiaRenderer {
+class WebGLSkiaRenderer : public rive::SkiaRenderer
+{
 private:
-  sk_sp<GrDirectContext> m_Context;
-  SkSurface *m_Surface;
+    sk_sp<GrDirectContext> m_Context;
+    SkSurface* m_Surface;
 
 public:
-  WebGLSkiaRenderer(sk_sp<GrDirectContext> context, int width, int height)
-      : m_Context(context),
-        m_Surface(makeSurface(context, width, height)), rive::SkiaRenderer(
-                                                            nullptr) {
-    m_Canvas = m_Surface->getCanvas();
-  }
+    WebGLSkiaRenderer(sk_sp<GrDirectContext> context, int width, int height) :
+        m_Context(context),
+        m_Surface(makeSurface(context, width, height)),
+        rive::SkiaRenderer(nullptr)
+    {
+        m_Canvas = m_Surface->getCanvas();
+    }
 
-  ~WebGLSkiaRenderer() { delete m_Surface; }
+    ~WebGLSkiaRenderer() { delete m_Surface; }
 
-  void resize(int width, int height) {
-    delete m_Surface;
-    m_Surface = makeSurface(m_Context, width, height);
-    m_Canvas = m_Surface->getCanvas();
-  }
+    void resize(int width, int height)
+    {
+        delete m_Surface;
+        m_Surface = makeSurface(m_Context, width, height);
+        m_Canvas = m_Surface->getCanvas();
+    }
 
-  void clear() { m_Canvas->clear(0); }
+    void clear() { m_Canvas->clear(0); }
 
-  void flush() {
-    m_Context->flush();
-  }
+    void flush() { m_Context->flush(); }
 
-  SkSurface *makeSurface(sk_sp<GrDirectContext> context, int width,
-                         int height) {
-    int numSamples, numStencilBits;
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glGetIntegerv(GL_SAMPLES, &numSamples);
-    glGetIntegerv(GL_STENCIL_BITS, &numStencilBits);
-    m_Context->resetContext(kRenderTarget_GrGLBackendState);
+    SkSurface* makeSurface(sk_sp<GrDirectContext> context, int width, int height)
+    {
+        int numSamples, numStencilBits;
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glGetIntegerv(GL_SAMPLES, &numSamples);
+        glGetIntegerv(GL_STENCIL_BITS, &numStencilBits);
+        m_Context->resetContext(kRenderTarget_GrGLBackendState);
 
-    GrGLFramebufferInfo framebufferInfo;
-    framebufferInfo.fFBOID = 0;
-    framebufferInfo.fFormat = GL_RGBA8;
+        GrGLFramebufferInfo framebufferInfo;
+        framebufferInfo.fFBOID = 0;
+        framebufferInfo.fFormat = GL_RGBA8;
 
-    GrBackendRenderTarget backendRenderTarget(width, height, numSamples,
-                                              numStencilBits, framebufferInfo);
+        GrBackendRenderTarget backendRenderTarget(width,
+                                                  height,
+                                                  numSamples,
+                                                  numStencilBits,
+                                                  framebufferInfo);
 
-    return SkSurface::MakeFromBackendRenderTarget(
-               context.get(), backendRenderTarget, kBottomLeft_GrSurfaceOrigin,
-               kRGBA_8888_SkColorType, nullptr, nullptr)
-        .release();
-  }
+        return SkSurface::MakeFromBackendRenderTarget(context.get(),
+                                                      backendRenderTarget,
+                                                      kBottomLeft_GrSurfaceOrigin,
+                                                      kRGBA_8888_SkColorType,
+                                                      nullptr,
+                                                      nullptr)
+            .release();
+    }
 
-  void saveClipRect(float l, float t, float r, float b) {
-    save();
-    std::unique_ptr<rive::RenderPath> rect(jsFactory()->makeEmptyRenderPath());
-    rect->moveTo(l, t);
-    rect->lineTo(r, t);
-    rect->lineTo(r, b);
-    rect->lineTo(l, b);
-    rect->close();
-    clipPath(rect.get());
-  }
+    void saveClipRect(float l, float t, float r, float b)
+    {
+        save();
+        std::unique_ptr<rive::RenderPath> rect(jsFactory()->makeEmptyRenderPath());
+        rect->moveTo(l, t);
+        rect->lineTo(r, t);
+        rect->lineTo(r, b);
+        rect->lineTo(l, b);
+        rect->close();
+        clipPath(rect.get());
+    }
 
-  void restoreClipRect() {
-    restore();
-  }
+    void restoreClipRect() { restore(); }
 };
 
-WebGLSkiaRenderer *makeSkiaRenderer(int width, int height) {
-  GrContextOptions options;
-  sk_sp<GrDirectContext> context = GrDirectContext::MakeGL(nullptr, options);
-  return new WebGLSkiaRenderer(context, width, height);
+WebGLSkiaRenderer* makeSkiaRenderer(int width, int height)
+{
+    GrContextOptions options;
+    sk_sp<GrDirectContext> context = GrDirectContext::MakeGL(nullptr, options);
+    return new WebGLSkiaRenderer(context, width, height);
 }
 
-EMSCRIPTEN_BINDINGS(RiveWASM_Skia) {
-  class_<rive::Renderer>("Renderer")
-      .function("save", &rive::Renderer::save)
-      .function("restore", &rive::Renderer::restore)
-      .function("transform", &rive::Renderer::transform, allow_raw_pointers())
-      .function("drawPath", &rive::Renderer::drawPath, allow_raw_pointers())
-      .function("clipPath", &rive::Renderer::clipPath, allow_raw_pointers())
-      .function("align", &rive::Renderer::align, allow_raw_pointers());
-  class_<WebGLSkiaRenderer, base<rive::Renderer>>("WebGLRenderer")
-      .function("clear", &WebGLSkiaRenderer::clear)
-      .function("flush", &WebGLSkiaRenderer::flush)
-      .function("resize", &WebGLSkiaRenderer::resize)
-      .function("saveClipRect", &WebGLSkiaRenderer::saveClipRect)
-      .function("restoreClipRect", &WebGLSkiaRenderer::restoreClipRect);
+EMSCRIPTEN_BINDINGS(RiveWASM_Skia)
+{
+    class_<rive::Renderer>("Renderer")
+        .function("save", &rive::Renderer::save)
+        .function("restore", &rive::Renderer::restore)
+        .function("transform", &rive::Renderer::transform, allow_raw_pointers())
+        .function("drawPath", &rive::Renderer::drawPath, allow_raw_pointers())
+        .function("clipPath", &rive::Renderer::clipPath, allow_raw_pointers())
+        .function("align",
+                  optional_override([](rive::Renderer& self,
+                                       rive::Fit fit,
+                                       JsAlignment alignment,
+                                       const rive::AABB& frame,
+                                       const rive::AABB& content) {
+                      self.align(fit, convertAlignment(alignment), frame, content);
+                  })) class_<WebGLSkiaRenderer, base<rive::Renderer>>("WebGLRenderer")
+        .function("clear", &WebGLSkiaRenderer::clear)
+        .function("flush", &WebGLSkiaRenderer::flush)
+        .function("resize", &WebGLSkiaRenderer::resize)
+        .function("saveClipRect", &WebGLSkiaRenderer::saveClipRect)
+        .function("restoreClipRect", &WebGLSkiaRenderer::restoreClipRect);
 
-  function("makeRenderer", &makeSkiaRenderer, allow_raw_pointers());
+    function("makeRenderer", &makeSkiaRenderer, allow_raw_pointers());
 }
 
-#endif   // RIVE_SKIA_RENDERER
+#endif // RIVE_SKIA_RENDERER

--- a/wasm/src/bindings_skia.cpp
+++ b/wasm/src/bindings_skia.cpp
@@ -6,6 +6,7 @@
 #include "SkCanvas.h"
 #include "SkSurface.h"
 #include "gl/GrGLInterface.h"
+#include "js_alignment.hpp"
 
 #include "skia_factory.hpp"
 #include "skia_renderer.hpp"
@@ -116,7 +117,8 @@ EMSCRIPTEN_BINDINGS(RiveWASM_Skia)
                                        const rive::AABB& frame,
                                        const rive::AABB& content) {
                       self.align(fit, convertAlignment(alignment), frame, content);
-                  })) class_<WebGLSkiaRenderer, base<rive::Renderer>>("WebGLRenderer")
+                  }));
+    class_<WebGLSkiaRenderer, base<rive::Renderer>>("WebGLRenderer")
         .function("clear", &WebGLSkiaRenderer::clear)
         .function("flush", &WebGLSkiaRenderer::flush)
         .function("resize", &WebGLSkiaRenderer::resize)

--- a/wasm/src/js_alignment.hpp
+++ b/wasm/src/js_alignment.hpp
@@ -1,0 +1,20 @@
+#ifndef _RIVE_JS_ALIGNMENT_HPP_
+#define _RIVE_JS_ALIGNMENT_HPP_
+
+#include "rive/layout.hpp"
+
+enum class JsAlignment : unsigned char
+{
+    topLeft,
+    topCenter,
+    topRight,
+    centerLeft,
+    center,
+    centerRight,
+    bottomLeft,
+    bottomCenter,
+    bottomRight
+};
+
+rive::Alignment convertAlignment(JsAlignment alignment);
+#endif


### PR DESCRIPTION
- Alignment now exposed as an enum so that emscripten doesn’t new it every time we get it.
- Use the same clang-format as the rest of our C++ code (gotta mino-repo this soon)
- Use address sanitizer for helping debug memory leaks in debug mode.
- Better compiler/linker flag separation between debug and release mode in our premake scripts.