### PR TITLE
add mouseover and mouseout events for pointer move

### DIFF
--- a/js/src/utils/registerTouchInteractions.js
+++ b/js/src/utils/registerTouchInteractions.js
@@ -43,6 +43,8 @@ export const registerTouchInteractions = ({
 
     switch (event.type) {
       // Pointer moving/hovering on the canvas
+      case "mouseover":
+      case "mouseout":
       case "mousemove": {
         for (const stateMachine of stateMachines) {
           stateMachine.pointerMove(transformedX, transformedY);
@@ -67,10 +69,14 @@ export const registerTouchInteractions = ({
     }
   };
   const callback = mouseCallback.bind(this);
+  canvas.addEventListener("mouseover", callback);
+  canvas.addEventListener("mouseout", callback);
   canvas.addEventListener("mousemove", callback);
   canvas.addEventListener("mousedown", callback);
   canvas.addEventListener("mouseup", callback);
   return () => {
+    canvas.removeEventListener("mouseover", callback);
+    canvas.removeEventListener("mouseout", callback);
     canvas.removeEventListener("mousemove", callback);
     canvas.removeEventListener("mousedown", callback);
     canvas.removeEventListener("mouseup", callback);


### PR DESCRIPTION
To add more accuracy to mouse behavior, adding the `mouseover` and `mouseout` events to trigger pointer move events for Listeners. This should be triggered if for example, a mouse is in the canvas already, and then quickly moved out of the canvas, where the browser would not trigger `mousemove` across that behavior. In this case, `mouseout` would always be called. 