### PR TITLE
fix: unload Mat2D object reference before transliterating to JS for canvas2d renderer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v11
         with:
-          version: 3.1.20
+          version: 3.1.29
           actions-cache-folder: "emsdk-cache"
       - name: Install premake
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git checkout origin/master
 cd ../../..
 ```
 
-4. Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html). We build against 3.1.20 in rive-wasm
+4. Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html). We build against 3.1.29 in rive-wasm
 5. Install [Premake5](https://premake.github.io/) and add it to your path
 
 6. `cd` back into the `js` folder and run `./build.sh` from your terminal/shell to build the latest WASM and builds for JS API's (high and low level) into the `npm/` folder. This may take some time, grab a coffee! This should finish with Webpack building the JS bundles for the high-level API packages (more on that below)

--- a/wasm/examples/parcel_example/index.js
+++ b/wasm/examples/parcel_example/index.js
@@ -1,9 +1,9 @@
 import "regenerator-runtime";
 // import RiveCanvas from "../../build/bin/debug/canvas_advanced_single.mjs";
-import RiveCanvas from "../../build/bin/debug/canvas_advanced.mjs";
+// import RiveCanvas from "../../build/bin/debug/canvas_advanced.mjs";
 // import RiveCanvas from "../../../js/npm/webgl_advanced_single/webgl_advanced_single.mjs";
 import { registerTouchInteractions } from "../../../js/src/utils";
-// import RiveCanvas from '../../../js/npm/canvas_advanced_single/canvas_advanced_single.mjs';
+import RiveCanvas from "../../../js/npm/canvas_advanced_single/canvas_advanced_single.mjs";
 import AvatarAnimation from "./look.riv";
 import TapeMeshAnimation from "./tape.riv";
 import BirdAnimation from "./birb.riv";
@@ -92,44 +92,6 @@ async function renderRiveAnimation({ rive, num, hasRandomSizes }) {
     alignment: rive.Alignment.center,
   });
 
-  function loadFile(droppedFile) {
-    const reader = new FileReader();
-    reader.onload = function (event) {
-      stateMachine = null;
-      const file = rive.load(new Uint8Array(event.target.result));
-      artboard = file.artboardByName("Truck");
-      animation = new rive.LinearAnimationInstance(
-        artboard.animationByName("idle"),
-        artboard
-      );
-    };
-
-    reader.readAsArrayBuffer(droppedFile);
-  }
-
-  document.body.addEventListener("dragover", function (ev) {
-    ev.preventDefault();
-  });
-  document.body.addEventListener("drop", function (ev) {
-    ev.preventDefault();
-
-    if (ev.dataTransfer.items) {
-      // Use DataTransferItemList interface to access the file(s)
-      for (var i = 0; i < ev.dataTransfer.items.length; i++) {
-        // If dropped items aren't files, reject them
-        if (ev.dataTransfer.items[i].kind === "file") {
-          loadFile(ev.dataTransfer.items[i].getAsFile());
-          break;
-        }
-      }
-    } else {
-      for (var i = 0; i < ev.dataTransfer.files.length; i++) {
-        loadFile(ev.dataTransfer.files[i]);
-        break;
-      }
-    }
-  });
-
   let lastTime = 0;
   let artboard, stateMachine, animation;
 
@@ -177,7 +139,7 @@ async function main() {
   const params = new Proxy(new URLSearchParams(window.location.search), {
     get: (searchParams, prop) => searchParams.get(prop),
   });
-  const numCanvases = parseInt(params.numCanvases || 0) || 10;
+  const numCanvases = parseInt(params.numCanvases || 0) || 20;
   const hasRandomSizes = !!params.hasRandomSizes || false;
   const rive = await RiveCanvas();
 
@@ -223,7 +185,7 @@ async function checkForLeaks(rive) {
   const renderer = rive.makeRenderer(canvas, true);
   var elapsedSeconds = 0.0167;
   // Render 20 frames.
-  for (var i = 0; i < 100; i++) {
+  for (var i = 0; i < 1000; i++) {
     renderer.clear();
     if (artboard) {
       if (stateMachine) {
@@ -259,10 +221,14 @@ async function checkForLeaks(rive) {
   if (animation) {
     animation.delete();
   }
+  if (artboard) {
+    artboard.delete();
+  }
   file.delete();
   rive.cleanup();
   // Report any leaks.
   rive.doLeakCheck();
+  console.log("END");
 }
 
 main();

--- a/wasm/premake5.lua
+++ b/wasm/premake5.lua
@@ -128,6 +128,7 @@ do
     buildoptions {
         '-g2',
         '-fsanitize=address'
+        -- '-fsanitize=leak'
     }
     linkoptions {
         '-s ERROR_ON_UNDEFINED_SYMBOLS=0',
@@ -136,6 +137,7 @@ do
         '-s DEMANGLE_SUPPORT=1',
         '-g2',
         '-fsanitize=address'
+        -- '-fsanitize=leak',
     }
 end
 

--- a/wasm/src/bindings_c2d.cpp
+++ b/wasm/src/bindings_c2d.cpp
@@ -88,13 +88,9 @@ public:
                    transform.ty());
     }
 
-    void align(RendererWrapper& self,
-               rive::Fit fit,
-               JsAlignment alignment,
-               rive::AABB foo,
-               rive::AABB bar)
+    void align(rive::Fit fit, JsAlignment alignment, const rive::AABB& foo, const rive::AABB& bar)
     {
-        self.transform(computeAlignment(fit, convertAlignment(alignment), foo, bar));
+        transform(computeAlignment(fit, convertAlignment(alignment), foo, bar));
     }
 
     void drawPath(rive::RenderPath* path, rive::RenderPaint* paint) override
@@ -404,14 +400,7 @@ EMSCRIPTEN_BINDINGS(RiveWASM_C2D)
         .function("transform", &RendererWrapper::transform, pure_virtual(), allow_raw_pointers())
         .function("drawPath", &RendererWrapper::drawPath, pure_virtual(), allow_raw_pointers())
         .function("clipPath", &RendererWrapper::clipPath, pure_virtual(), allow_raw_pointers())
-        .function("align",
-                  optional_override(
-                      [](RendererWrapper& self,
-                         rive::Fit fit,
-                         JsAlignment alignment,
-                         const rive::AABB& foo,
-                         const rive::AABB& bar) { self.align(self, fit, alignment, foo, bar); }),
-                  allow_raw_pointers())
+        .function("align", &RendererWrapper::align, pure_virtual(), allow_raw_pointers())
         .allow_subclass<RendererWrapper>("RendererWrapper");
 
     class_<rive::RenderPath>("RenderPath")


### PR DESCRIPTION
**Problem**: We're noticing a memory leak that's slow-burning on the memory footprint of an app that uses `@rive-app/canvas`. Because we allow memory to grow when building WASM, it's not immediately evident unless you run an app for potentially several hours.

**tl;dr:** Unload `Mat2D` properties, which are just floats, before calling into JS for a few functions.

After turning off `'-s ALLOW_MEMORY_GROWTH=1'` in our premake config on debug mode and running against the WASM `parcel_example` app with about 20 canvases going, it'll crash the app in a few seconds. Interestingly, WASM doesn't report a memory leak using our [memory leak test function](https://github.com/rive-app/rive-wasm/blob/master/wasm/examples/parcel_example/index.js#L193). So it's not that our JS heap is growing in size, but rather something is driving memory usage up on the browser that emscripten doesn't seem to be catching.

After a bit of a chase to find the leak, it seems that any CPP binding that calls into JS (`renderer.js`) to do some calculation **with** an object reference in particular as a parameter seems to be an offending case here. This is used in a few spots with respect to `.transform()` and `.addRenderPath()` in CPP-land, which call into JS with a `const rive::Mat2D& transform` object. Pointers and primitive types don't seem to be problematic in this conversion.

Some folks have tried to raise this - but nothing super clear [here](https://github.com/emscripten-core/emscripten/issues/9930). Also, the docs don't give examples or guidance on this case so hard to tell the main issue beyond Emscripten trying to make a copy of the object before passing to JS from what I think I'm gathering.

**Solution (for now)**: What seemed to have fixed the main issue for rendering right now is instead of passing the `Mat2D` object reference to JS, just unpacking the values of it and sending it to JS instead, since they're just `float` primitives. This is a purely internal call API change, so nothing consumer-facing and shouldn't be breaking.

Next steps I think are to try and re-create this underlying reference issue in a standalone WASM example and try to raise with the Emscripten team if we can

