### PR TITLE
fixed iphone xr 14.5-14.6 can't display bug

### DIFF
--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -95,7 +95,7 @@ const offscreenWebGL = new (function () {
       gl.bindAttribLocation(program, UV_ARRAY, "uv");
       gl.linkProgram(program);
       const log = gl.getProgramInfoLog(program);
-      if (log.length > 0) {
+      if (log.trim().length > 0) {
         throw log;
       }
       _matUniform = gl.getUniformLocation(program, "mat");


### PR DESCRIPTION
`const log = gl.getProgramInfoLog(program);`
In iPhone XR iOS 14.5 - 14.6 result is "↵" 
The result returned by the log is an unexpected string length.
So the main program will breaks.