### PR TITLE
fix: add git credentials and add a GITHUB_TOKEN to allow pushing a commit from ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           version: 3.1.29
           actions-cache-folder: "emsdk-cache"
+      - name: Setup Git config
+        run: |
+          git config --local user.email 'hello@rive.app'
+          git config --local user.name ${{ github.actor }}
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
@@ -41,6 +45,7 @@ jobs:
         run: npm run release:major
         working-directory: ./js
         env:
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
           PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{inputs.major == false && inputs.minor == true}}
@@ -48,6 +53,7 @@ jobs:
         run: npm run release:minor
         working-directory: ./js
         env:
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
           PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{inputs.major == false && inputs.minor == false}}
@@ -55,9 +61,6 @@ jobs:
         run: npm run release:patch
         working-directory: ./js
         env:
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
           PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Setup Git config
-        run: |
-          git config --local user.email 'hello@rive.app'
-          git config --local user.name ${{ github.actor }}

--- a/js/npm/canvas/package.json
+++ b/js/npm/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/canvas",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's canvas based web api.",
   "main": "rive.js",
   "homepage": "https://rive.app",

--- a/js/npm/canvas_advanced/package.json
+++ b/js/npm/canvas_advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/canvas-advanced",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's lightweight low-level canvas based web api.",
   "main": "canvas_advanced.mjs",
   "homepage": "https://rive.app",

--- a/js/npm/canvas_advanced_single/package.json
+++ b/js/npm/canvas_advanced_single/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/canvas-advanced-single",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's lightweight low-level canvas based web api all in one js file.",
   "main": "canvas_advanced_single.mjs",
   "homepage": "https://rive.app",

--- a/js/npm/canvas_single/package.json
+++ b/js/npm/canvas_single/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/canvas-single",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's high-level canvas based web api all in one js file.",
   "main": "rive.js",
   "homepage": "https://rive.app",

--- a/js/npm/webgl/package.json
+++ b/js/npm/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/webgl",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's webgl based web api.",
   "main": "rive.js",
   "homepage": "https://rive.app",

--- a/js/npm/webgl_advanced/package.json
+++ b/js/npm/webgl_advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/webgl-advanced",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's webgl low-level canvas based web api.",
   "main": "webgl_advanced.mjs",
   "homepage": "https://rive.app",

--- a/js/npm/webgl_advanced_single/package.json
+++ b/js/npm/webgl_advanced_single/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/webgl-advanced-single",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's webgl low-level canvas based web api all in one js file.",
   "main": "webgl_advanced_single.mjs",
   "homepage": "https://rive.app",

--- a/js/npm/webgl_single/package.json
+++ b/js/npm/webgl_single/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/webgl-single",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Rive's webgl based web api with bundled wasm.",
   "main": "rive.js",
   "homepage": "https://rive.app",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rive-app/canvas",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rive-app/canvas",
   "private": true,
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Helper for building rive-api combinations (multiple separate packages).",
   "homepage": "https://rive.app",
   "repository": {


### PR DESCRIPTION
Tested the new CI release flow - small issue was pushing back the bumped version numbers back to the repo because GIt didn't have author credentials setup on the publish flow.