### PR TITLE
fix: add safety checks before invoking cleanup on renderer and file on main cleanup function

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1453,8 +1453,10 @@ export class Rive {
     this.cleanupInstances();
     // Delete the renderer
     this.renderer?.delete();
+    this.renderer = null;
     // Delete the rive file
     this.file?.delete();
+    this.file = null;
   }
 
   /**

--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1452,9 +1452,9 @@ export class Rive {
     // Clean up any artboard, animation or state machine instances.
     this.cleanupInstances();
     // Delete the renderer
-    this.renderer.delete();
+    this.renderer?.delete();
     // Delete the rive file
-    this.file.delete();
+    this.file?.delete();
   }
 
   /**

--- a/js/test/rive.test.ts
+++ b/js/test/rive.test.ts
@@ -1162,4 +1162,15 @@ test("Rive deletes instances on the cleanup", (done) => {
   });
 });
 
+test("Rive doesn't error out when cleaning up if the file is not set yet", () => {
+  const canvas = document.createElement("canvas");
+  const r = new rive.Rive({
+    canvas: canvas,
+    buffer: stateMachineFileBuffer,
+    autoplay: true,
+    artboard: "MyArtboard",
+  });
+  r.cleanup();
+});
+
 // #endregion


### PR DESCRIPTION
Issue brought up on Discord where a user is trying to clean up instances where a file instance may not be created yet. Adding a few null safety checks before calling `.delete()` in the cleanup function to ensure this case is handled.