### PR TITLE
fix for loop over animatables without changing typescript target

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -496,7 +496,7 @@ class Animator {
       // Play/pause already instanced items, or create new instances
       const instancedAnimationNames = this.animations.map((a) => a.name);
       const instancedMachineNames = this.stateMachines.map((m) => m.name);
-      for (const [i] of animatables.entries()) {
+      for (let i = 0; i < animatables.length; i++) {
         const aIndex = instancedAnimationNames.indexOf(animatables[i]);
         const mIndex = instancedMachineNames.indexOf(animatables[i]);
         if (aIndex >= 0 || mIndex >= 0) {


### PR DESCRIPTION
Typescript build failed on this recent change due to Typescript config targeting es5 and not supporting interating on iterators in the `.entries()` case. A probably easier and safer option for now is just to switch this to a traditional index for loop, before moving the target up to es2015 (which is probably fine honestly, but for a small change this might be safer). 