### PR TITLE
fix: set fetch depth to 0 to grab tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v11


### PR DESCRIPTION
Ran into a weird bug with the recently added changelog workflow -- the auto-changelog lib we use was trying to grab tags for internal logic and failed because the checkout action we use doesn't pull tags automatically. This small change should fetch the tags so that `auto-changelog` can do its own parsing