### PR TITLE
Add: export ImageAsset and FontAsset types

### DIFF
--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -883,6 +883,14 @@ export declare class FileAsset {
   cdnUuid: string;
 }
 
+export declare class ImageAsset extends FileAsset {
+  setRenderImage(image: Image): void;
+}
+
+export declare class FontAsset extends FileAsset {
+  setFont(font: Font): void;
+}
+
 export declare class FileAssetLoader {}
 
 export declare class CustomFileAssetLoader extends FileAssetLoader {


### PR DESCRIPTION
Added so that I could cast a FileAsset to ImageAsset or FontAsset and call setRenderImage or setFont without TypeScript getting angry.