### PR TITLE
Include types declaration in webgl advanced packages

### DIFF
--- a/js/npm/webgl_advanced/package.json
+++ b/js/npm/webgl_advanced/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "files": [
     "webgl_advanced.mjs",
-    "rive.wasm"
+    "rive.wasm",
+    "rive_advanced.mjs.d.ts"
   ],
   "types": "rive_advanced.mjs.d.ts",
   "dependencies": {},

--- a/js/npm/webgl_advanced_single/package.json
+++ b/js/npm/webgl_advanced_single/package.json
@@ -22,7 +22,8 @@
   ],
   "license": "MIT",
   "files": [
-    "webgl_advanced_single.mjs"
+    "webgl_advanced_single.mjs",
+    "rive_advanced.mjs.d.ts"
   ],
   "types": "rive_advanced.mjs.d.ts",
   "dependencies": {},


### PR DESCRIPTION
## Purpose

The `@rive-app/webgl-advanced` and `@rive-app/webgl-advanced-single` packages do not contain the TS declarations in their published npm modules.

Add the generated `rive_advanced.mjs.d.ts` declarations file to the module's `files` for publishing.