### PR TITLE
add optional param for method resizeDrawingSurfaceToCanvas

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1903,10 +1903,10 @@ export class Rive {
    * and resize the layout to match the new drawing surface afterwards.
    * Useful function for consumers to include in a window resize listener
    */
-  public resizeDrawingSurfaceToCanvas() {
+  public resizeDrawingSurfaceToCanvas(customDevicePixelRatio?: number) {
     if (this.canvas instanceof HTMLCanvasElement && !!window) {
       const { width, height } = this.canvas.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
+      const dpr = customDevicePixelRatio || window.devicePixelRatio || 1;
       this.canvas.width = dpr * width;
       this.canvas.height = dpr * height;
       this.startRendering();


### PR DESCRIPTION
 I have suggestions to add to the `resizeDrawingSurfaceToCanvas(devicePixelRatio)` method, an optional argument that you can pass a value to.
 
When using the `resizeDrawingSurfaceToCanvas() `=> method when resizing, it takes into account the DPR of the device and multiplies the width and height by that value. That it starts to lag on weak devices, where the difference between smaller and larger canvas resolution is not so great, but the difference in performance is noticeable.


if you use resizeDrawingSurfaceToCanvas()
![Screen Shot 2024-01-04 at 14 52 54](https://github.com/rive-app/rive-wasm/assets/66491452/6fb4b786-5b38-4df9-9153-b17d51a56d48)
----------------------------------

if you use resizeDrawingSurfaceToCanvas(customDPR)
![Screen Shot 2024-01-04 at 14 52 15](https://github.com/rive-app/rive-wasm/assets/66491452/2f1fa3ae-cd8c-48de-bcd9-3a89964decca)

it gives a good performance for weak devices, since the browser doesn't have to render 2x-3x canvas (the difference is almost insignificant to the eye).
customDPR (1.5) set increases the width and height of the canvas by 1.5x
