### PR TITLE
Fix: canvas's context2d property update timing

### DIFF
--- a/wasm/js/renderer.js
+++ b/wasm/js/renderer.js
@@ -946,7 +946,9 @@ Module["onRuntimeInitialized"] = function () {
       },
       set(target, property, value) {
         if (property in c2dSource) {
-          c2dSource[property] = value;
+          newCanvasRenderer._drawList.push(() => {
+            c2dSource[property] = value;
+          });
           return true;
         }
       },


### PR DESCRIPTION
## Summary

This PR aims to fix the issue detailed in #360.

The issue stems from the native context2d calls being queued up to be executed later. This creates a rift between the draw calls and the setting of properties.

The proposed solution creates a closure for each property setter call and adds it to the draw queue, ensuring that the order of the draw calls and the property setters remains consistent chronologically.
