### PR TITLE
fix: initialize `observed` to prevent `undefined`

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1489,7 +1489,7 @@ export class Rive {
   private loaded = false;
 
   // Reference of an object that handles any observers for the animation
-  private _observed: ObservedObject | null;
+  private _observed: ObservedObject | null = null;
 
   /**
    * Tracks if a Rive file is loaded; we need this in addition to loaded as some


### PR DESCRIPTION
See #375 for more details.