### PR TITLE
If there is no artboard, running cleanup() will cause an error

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -2251,7 +2251,10 @@ export class Rive {
       });
       return;
     }
-    this.animator.stop(animationNames);
+    // If there is no artboard, this.animator will be undefined
+    if (this.animator) {
+      this.animator.stop(animationNames);
+    }
     if (this.eventCleanup) {
       this.eventCleanup();
     }


### PR DESCRIPTION
If there is no artboard, `this.animator` will be `undefined`. If you run `cleanup()`, it will try to run `this.animator.stop(animationNames);`, which will result in the following error. 

![Screenshot 2024-11-13 at 12 08 13 PM (3)](https://github.com/user-attachments/assets/0056fd9c-f33c-4bc7-b47c-6ec990b3397a)

This PR makes sure `this.animator` exists before trying to call `this.animator.stop(animationNames);`. 