### PR TITLE
feat: expose wasmBinary to allow Rive being used in environments without access to fetch and XHR

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -222,6 +222,8 @@ export class RuntimeLoader {
   // if embedded wasm is used then this is never used.
   private static wasmURL = `https://unpkg.com/${packageData.name}@${packageData.version}/rive.wasm`;
 
+  private static wasmBinary: ArrayBuffer;
+
   // Class is never instantiated
   private constructor() {}
 
@@ -230,6 +232,7 @@ export class RuntimeLoader {
     rc.default({
       // Loads Wasm bundle
       locateFile: () => RuntimeLoader.wasmURL,
+      wasmBinary: RuntimeLoader.wasmBinary
     })
       .then((rive: rc.RiveCanvas) => {
         RuntimeLoader.runtime = rive;
@@ -314,6 +317,15 @@ export class RuntimeLoader {
   // Gets the current wasm url
   public static getWasmUrl(): string {
     return RuntimeLoader.wasmURL;
+  }
+  // Manually sets the wasm binary
+  public static setWasmBinary(ab: ArrayBuffer): void {
+    RuntimeLoader.wasmBinary = ab;
+  }
+
+  // Gets the current wasm url
+  public static getWasmBinary(): ArrayBuffer {
+    return RuntimeLoader.wasmBinary;
   }
 }
 

--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -1,5 +1,6 @@
 interface RiveOptions {
   locateFile(file: string): string;
+  wasmBinary?: ArrayBuffer;
 }
 
 declare function Rive(options?: RiveOptions): Promise<RiveCanvas>;


### PR DESCRIPTION
This change allows the end-user of canvas and react-canvas to use the previously undocumented wasmBinary config field to pass an ArrayBuffer directly.

We've arrived at this as a solution for using Rive without giving it access to fetch and XHR at all 
(it's frowned upon by browser extension review process to have code that could, even potentially, load sources from the web and execute within the extension) 

We're running Rive under LavaMoat, so we can deny it access to fetch while keeping it for ourselves. 

The option seemed very convenient, so I thought I'd offer it as a contribution.