### PR TITLE
fix: add new types to be released in high-level runtimes too for package.jsons

### DIFF
--- a/js/npm/canvas/package.json
+++ b/js/npm/canvas/package.json
@@ -27,7 +27,9 @@
     "rive.wasm",
     "rive_fallback.wasm",
     "rive.d.ts",
-    "rive_advanced.mjs.d.ts"
+    "rive_advanced.mjs.d.ts",
+    "runtimeLoader.d.ts",
+    "utils"
   ],
   "typings": "rive.d.ts",
   "dependencies": {},

--- a/js/npm/canvas_lite/package.json
+++ b/js/npm/canvas_lite/package.json
@@ -27,7 +27,9 @@
     "rive.wasm",
     "rive_fallback.wasm",
     "rive.d.ts",
-    "rive_advanced.mjs.d.ts"
+    "rive_advanced.mjs.d.ts",
+    "runtimeLoader.d.ts",
+    "utils"
   ],
   "typings": "rive.d.ts",
   "dependencies": {},

--- a/js/npm/canvas_single/package.json
+++ b/js/npm/canvas_single/package.json
@@ -25,7 +25,9 @@
     "rive.js",
     "rive.js.map",
     "rive.d.ts",
-    "rive_advanced.mjs.d.ts"
+    "rive_advanced.mjs.d.ts",
+    "runtimeLoader.d.ts",
+    "utils"
   ],
   "typings": "rive.d.ts",
   "dependencies": {},

--- a/js/npm/webgl2/package.json
+++ b/js/npm/webgl2/package.json
@@ -27,7 +27,9 @@
     "rive.wasm",
     "rive.js.map",
     "rive.d.ts",
-    "rive_advanced.mjs.d.ts"
+    "rive_advanced.mjs.d.ts",
+    "runtimeLoader.d.ts",
+    "utils"
   ],
   "typings": "rive.d.ts",
   "dependencies": {},


### PR DESCRIPTION
Upstream repo will also push a change that includes new extra type files for a few high-level JS runtime package.json's. Adding it here so the next sync will not be affected. Short term fix for now