### PR TITLE
Fix/fit layout responsive and zero guard

### DIFF
--- a/js/examples/_frameworks/fit_layout_zero_repro/README.md
+++ b/js/examples/_frameworks/fit_layout_zero_repro/README.md
@@ -1,0 +1,72 @@
+# Fit.Layout — display:none-on-mount repro
+
+Demonstrates two bugs in `@rive-app/canvas` 2.37.x that affect `Fit.Layout` consumers whose canvas mounts inside a hidden ancestor (skeleton/loader pattern):
+
+1. **Bug 2 — `resizeDrawingSurfaceToCanvas` writes 0 to the artboard.** When the canvas is inside a `display:none` ancestor, `getBoundingClientRect()` returns `0×0`. The `Fit.Layout` branch blindly writes `0/scaleFactor` to `artboard.width` and `artboard.height`. The state machine then commits child positions against a zero-dimension layout box; the residue persists after the canvas later becomes visible.
+
+2. **Bug 1 — `onCanvasResize` only re-fits on visibility toggle.** The `ResizeObserver` fires on every dimension change, but `onCanvasResize` collapses each event into a `hasZeroSize` boolean and only triggers `resizeDrawingSurfaceToCanvas()` when that boolean toggles. Non-zero → non-zero deltas (scrollbar appearance, sibling reflow, web font swap) are silently dropped, so `artboard.width/height` drift stale.
+
+Both pages put two canvases side by side: a **control** (always visible, baseline rendering) and a **buggy** (mounts inside `display:none`, `resizeDrawingSurfaceToCanvas()` called in `onLoad`). The on-page log captures `artboard.width/height` and canvas dimensions at each step.
+
+## Two ways to run
+
+| File                      | Runtime source                                | Use case                                                                 |
+| ------------------------- | --------------------------------------------- | ------------------------------------------------------------------------ |
+| `standalone.html`         | Published `@rive-app/canvas@2.37.6` via unpkg | Open immediately, no local build. Suitable as a GitHub issue attachment. |
+| `index.html` (`index.ts`) | Local `../../../npm/canvas_single` build      | Verify the fix end-to-end by rebuilding after applying the patches.      |
+
+Both files reuse `../layout_example/assets/layout_test.riv` — no asset duplication.
+
+### Running `standalone.html`
+
+```bash
+cd js/examples/_frameworks
+npx serve -l 8765 .          # or python3 -m http.server 8765
+open http://localhost:8765/fit_layout_zero_repro/standalone.html
+```
+
+### Running `index.html` (parcel against the local build)
+
+> **Requires emscripten + a built `npm/canvas_single` first.** If you don't have emscripten installed and just want to see the bug, use `standalone.html` above instead — it needs no local build. Without the WASM build, `npm start` will fail with `Could not load './rive.js' from module '@rive-app/canvas-single'` because `npm/canvas_single/rive.js` is a build artifact that doesn't ship in the repo.
+
+```bash
+# 1. (One-time) install emscripten — downloads SDK 3.1.61, ~5–15 min.
+cd ../../wasm
+./get_emcc.sh
+
+# 2. Build the canvas_single bundle from the local (patched) source.
+cd ../js
+./build.sh -r canvas-single
+
+# 3. Install parcel and serve.
+cd examples/_frameworks/fit_layout_zero_repro
+npm install
+npm start                    # parcel: http://localhost:1234
+```
+
+## What the log shows
+
+Pre-fix:
+
+```text
+[control] onLoad                       artboard:{w:466,h:70}   canvas:466×70
+[buggy] onLoad (before resize)         artboard:{w:500,h:500}  canvas:0×0   ← design dimensions, healthy
+[buggy] onLoad (after resize)          artboard:{w:0,h:0}      canvas:0×0   ← Bug 2 fired
+[buggy] after reveal                   artboard:{w:466,h:70}   canvas:466×70 ← recovers via zero→nonzero toggle
+[buggy] shrink W to 200                artboard:{w:466,h:70}   canvas:cssW:200, backW:466 ← Bug 1: backing not updated
+[buggy] shrink H to 55                 artboard:{w:466,h:70}   canvas:466×55 ← Bug 1: artboard stale, top/bottom clipped
+```
+
+Post-fix:
+
+```text
+[buggy] onLoad (after resize)          artboard:{w:500,h:500}  ← Bug 2 fixed: 0×0 write skipped
+[buggy] shrink W to 200                artboard:{w:200,h:70}   ← Bug 1 fixed: re-fit on dimension delta
+[buggy] shrink H to 55                 artboard:{w:466,h:55}   ← Bug 1 fixed: re-fit on dimension delta
+```
+
+## Why the bug is intermittent in real apps
+
+Bug 2 is timing-dependent: it fires only when `resizeDrawingSurfaceToCanvas()` is called while the canvas's ancestor is still `display:none`. That depends on race conditions — network latency for the `.riv` fetch, WASM init time, when the consumer's loading/skeleton state transitions, etc. Hard-refreshing the same page can give you the bug sometimes and a clean render other times.
+
+Once Bug 2 fires, Bug 1 prevents recovery on subsequent layout shifts: even if the canvas later becomes visible, every further dimension change is silently dropped, so the artboard never re-fits.

--- a/js/examples/_frameworks/fit_layout_zero_repro/index.html
+++ b/js/examples/_frameworks/fit_layout_zero_repro/index.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fit.Layout — display:none-on-mount repro</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          sans-serif;
+        margin: 0;
+        padding: 24px;
+        max-width: 820px;
+      }
+      h1 {
+        font-size: 1.4rem;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 1rem;
+        margin: 16px 0 4px;
+      }
+      code {
+        background: #f0f0f0;
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-size: 0.9em;
+      }
+      #wrapper {
+        display: none;
+        width: 466px;
+        height: 70px;
+        background: #fff;
+        border: 1px dashed #bbb;
+      }
+      #wrapper.revealed {
+        display: block;
+      }
+      #control-wrapper {
+        width: 466px;
+        height: 70px;
+        background: #fff;
+        border: 1px dashed #bbb;
+      }
+      canvas {
+        width: 466px;
+        height: 70px;
+        display: block;
+      }
+      button {
+        padding: 8px 14px;
+        font-size: 13px;
+        cursor: pointer;
+        border: 1px solid #888;
+        background: #fafafa;
+        border-radius: 4px;
+      }
+      button:hover {
+        background: #eee;
+      }
+      pre {
+        background: #1e1e1e;
+        color: #d4d4d4;
+        padding: 12px;
+        border-radius: 4px;
+        font-size: 12px;
+        line-height: 1.5;
+        max-height: 300px;
+        overflow: auto;
+      }
+      .controls {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin: 12px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Fit.Layout — display:none-on-mount repro (parcel + local build)</h1>
+    <p>
+      Builds against the local <code>npm/canvas_single</code> bundle. After
+      applying the fix and rebuilding (<code>./build.sh -r canvas-single</code>
+      from <code>js/</code>), reload to confirm the bug is gone.
+    </p>
+    <div class="controls">
+      <button id="show">Reveal the buggy canvas</button>
+      <button id="shrinkW">Shrink WIDTH 466 → 200</button>
+      <button id="shrinkH">Shrink HEIGHT 70 → 55</button>
+    </div>
+    <h2>Control canvas — always visible</h2>
+    <div id="control-wrapper">
+      <canvas id="riveCanvasControl"></canvas>
+    </div>
+    <h2>Buggy canvas — mounts inside <code>display:none</code></h2>
+    <div id="wrapper">
+      <canvas id="riveCanvas"></canvas>
+    </div>
+    <pre id="log"></pre>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/js/examples/_frameworks/fit_layout_zero_repro/index.ts
+++ b/js/examples/_frameworks/fit_layout_zero_repro/index.ts
@@ -1,0 +1,126 @@
+import "regenerator-runtime";
+import { Rive, Fit, Alignment, Layout } from "@rive-app/canvas";
+
+// Reuse the existing layout test asset from the sibling layout_example.
+const RiveLayoutTest = new URL("/assets/layout_test.riv", import.meta.url);
+
+async function loadRiveFile(): Promise<ArrayBuffer> {
+  return await (await fetch(new Request(RiveLayoutTest))).arrayBuffer();
+}
+
+const logEl = document.getElementById("log") as HTMLPreElement;
+const wrapper = document.getElementById("wrapper") as HTMLDivElement;
+const canvas = document.getElementById("riveCanvas") as HTMLCanvasElement;
+const canvasControl = document.getElementById(
+  "riveCanvasControl",
+) as HTMLCanvasElement;
+
+interface RiveLike {
+  artboardWidth: number;
+  artboardHeight: number;
+  resizeDrawingSurfaceToCanvas: () => void;
+}
+
+const log = (label: string, payload?: unknown) => {
+  const t = performance.now().toFixed(0).padStart(5, " ");
+  const line =
+    `[${t}ms] ${label}` +
+    (payload === undefined ? "" : "  " + JSON.stringify(payload));
+  logEl.textContent += line + "\n";
+  console.log("[repro]", label, payload);
+};
+
+const snapshot = (
+  label: string,
+  instance: RiveLike,
+  canvasEl: HTMLCanvasElement,
+) => {
+  log(label, {
+    artboard: { w: instance.artboardWidth, h: instance.artboardHeight },
+    canvas: {
+      cssW: canvasEl.clientWidth,
+      cssH: canvasEl.clientHeight,
+      backW: canvasEl.width,
+      backH: canvasEl.height,
+    },
+  });
+};
+
+async function main() {
+  const buffer = await loadRiveFile();
+
+  // Control canvas — always visible. Baseline for the layout.
+  const rControl = new Rive({
+    canvas: canvasControl,
+    buffer,
+    layout: new Layout({ fit: Fit.Layout, alignment: Alignment.Center }),
+    autoplay: true,
+    stateMachines: ["State Machine 1"],
+    onLoad: () => {
+      rControl.resizeDrawingSurfaceToCanvas();
+      snapshot(
+        "[control] onLoad",
+        rControl as unknown as RiveLike,
+        canvasControl,
+      );
+    },
+  }) as unknown as RiveLike;
+
+  // Buggy canvas — mounts inside display:none, resize called in onLoad.
+  // Realistic consumer pattern (matches layout_example/index.ts).
+  const rive: RiveLike = new Rive({
+    canvas,
+    buffer,
+    layout: new Layout({ fit: Fit.Layout, alignment: Alignment.Center }),
+    autoplay: true,
+    stateMachines: ["State Machine 1"],
+    onLoad: () => {
+      snapshot("[buggy] onLoad (before resize)", rive, canvas);
+      // Bug 2 fires here when the canvas is inside display:none — the
+      // Fit.Layout branch writes 0/scaleFactor into artboard.width/height.
+      rive.resizeDrawingSurfaceToCanvas();
+      snapshot("[buggy] onLoad (after resize)", rive, canvas);
+    },
+  }) as unknown as RiveLike;
+
+  document.getElementById("show")!.addEventListener("click", () => {
+    wrapper.classList.add("revealed");
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() =>
+        snapshot("[buggy] after reveal", rive, canvas),
+      );
+    });
+  });
+
+  document.getElementById("shrinkW")!.addEventListener("click", () => {
+    // Width shrink 466 → 200 — non-zero → non-zero shift. Bug 1 drops it
+    // so backing stays wide, CSS shrinks, browser stretches the bitmap →
+    // visible horizontal squish.
+    canvas.style.width = "200px";
+    wrapper.style.width = "200px";
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() =>
+        snapshot("[buggy] shrink W to 200", rive, canvas),
+      );
+    });
+  });
+
+  document.getElementById("shrinkH")!.addEventListener("click", () => {
+    // Height shrink with canvas backing forced to match CSS (mimicking a
+    // `(window:resize)` listener). Artboard stays stale → Alignment.Center
+    // clips top/bottom of the design.
+    const newH = 55;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.style.height = newH + "px";
+    wrapper.style.height = newH + "px";
+    canvas.height = dpr * newH;
+    canvas.width = dpr * canvas.clientWidth;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() =>
+        snapshot(`[buggy] shrink H to ${newH}`, rive, canvas),
+      );
+    });
+  });
+}
+
+main();

--- a/js/examples/_frameworks/fit_layout_zero_repro/package.json
+++ b/js/examples/_frameworks/fit_layout_zero_repro/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "parcel_fit_layout_zero_repro",
+  "version": "1.0.0",
+  "description": "Reproduces the Fit.Layout artboard 0×0 / dimension-delta bugs against the local canvas_single build.",
+  "private": true,
+  "scripts": {
+    "start": "parcel index.html",
+    "build": "parcel build index.html --public-url ."
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "parcel": "^2.13.3"
+  },
+  "dependencies": {
+    "@rive-app/canvas": "file:../../../npm/canvas_single",
+    "regenerator-runtime": "^0.14.1"
+  }
+}

--- a/js/examples/_frameworks/fit_layout_zero_repro/standalone.html
+++ b/js/examples/_frameworks/fit_layout_zero_repro/standalone.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fit.Layout — display:none-on-mount repro</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          sans-serif;
+        margin: 0;
+        padding: 24px;
+        max-width: 820px;
+      }
+      h1 {
+        font-size: 1.4rem;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 1rem;
+        margin: 16px 0 4px;
+      }
+      p {
+        line-height: 1.5;
+        color: #333;
+      }
+      code {
+        background: #f0f0f0;
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-size: 0.9em;
+      }
+      #wrapper {
+        display: none;
+        width: 466px;
+        height: 70px;
+        background: #fff;
+        border: 1px dashed #bbb;
+      }
+      #wrapper.revealed {
+        display: block;
+      }
+      #control-wrapper {
+        width: 466px;
+        height: 70px;
+        background: #fff;
+        border: 1px dashed #bbb;
+      }
+      canvas {
+        width: 466px;
+        height: 70px;
+        display: block;
+      }
+      button {
+        padding: 8px 14px;
+        font-size: 13px;
+        cursor: pointer;
+        border: 1px solid #888;
+        background: #fafafa;
+        border-radius: 4px;
+      }
+      button:hover {
+        background: #eee;
+      }
+      pre {
+        background: #1e1e1e;
+        color: #d4d4d4;
+        padding: 12px;
+        border-radius: 4px;
+        font-size: 12px;
+        line-height: 1.5;
+        max-height: 300px;
+        overflow: auto;
+      }
+      .controls {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin: 12px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Fit.Layout — display:none-on-mount repro</h1>
+    <p>
+      Reproduces two bugs in <code>@rive-app/canvas</code> 2.37.x affecting
+      <code>Fit.Layout</code> consumers whose canvas mounts inside a hidden
+      ancestor:
+    </p>
+    <ol>
+      <li>
+        <strong>Bug 2:</strong>
+        <code>resizeDrawingSurfaceToCanvas()</code> writes <code>0</code> into
+        <code>artboard.width/height</code> when
+        <code>getBoundingClientRect()</code> reports <code>0×0</code> (canvas
+        hidden via <code>display:none</code> ancestor).
+      </li>
+      <li>
+        <strong>Bug 1:</strong> <code>ResizeObserver</code> fires on every size
+        change, but <code>Rive.onCanvasResize</code> only re-fits on zero ↔
+        non-zero toggles — non-zero → non-zero deltas (reflow, font load,
+        scrollbar) are silently dropped.
+      </li>
+    </ol>
+    <p>
+      Uses the published <code>@rive-app/canvas@2.37.6</code> via unpkg, so no
+      local build required. Just <code>npx serve</code> from
+      <code>js/examples/_frameworks/</code> and open this file.
+    </p>
+
+    <div class="controls">
+      <button id="show">Reveal the buggy canvas</button>
+      <button id="shrinkW">Shrink WIDTH 466 → 200</button>
+      <button id="shrinkH">Shrink HEIGHT 70 → 55</button>
+    </div>
+
+    <h2>Control canvas — always visible</h2>
+    <div id="control-wrapper">
+      <canvas id="rive-control"></canvas>
+    </div>
+
+    <h2>
+      Buggy canvas — mounts inside <code>display:none</code>, resize called on
+      load
+    </h2>
+    <div id="wrapper">
+      <canvas id="rive"></canvas>
+    </div>
+
+    <pre id="log"></pre>
+
+    <script src="https://unpkg.com/@rive-app/canvas@2.37.6"></script>
+    <script>
+      const { Rive, Layout, Fit, Alignment } = window.rive;
+
+      // Use the existing layout test asset from the sibling layout_example.
+      const RIVE_SRC = "../layout_example/assets/layout_test.riv";
+
+      const logEl = document.getElementById("log");
+      const wrapper = document.getElementById("wrapper");
+      const canvas = document.getElementById("rive");
+      const canvasControl = document.getElementById("rive-control");
+
+      const log = (label, payload) => {
+        const t = performance.now().toFixed(0).padStart(5, " ");
+        const line =
+          `[${t}ms] ${label}` +
+          (payload === undefined ? "" : "  " + JSON.stringify(payload));
+        logEl.textContent += line + "\n";
+        console.log("[repro]", label, payload);
+      };
+
+      const snapshot = (label, instance, canvasEl) => {
+        log(label, {
+          artboard: { w: instance.artboardWidth, h: instance.artboardHeight },
+          canvas: {
+            cssW: canvasEl.clientWidth,
+            cssH: canvasEl.clientHeight,
+            backW: canvasEl.width,
+            backH: canvasEl.height,
+          },
+        });
+      };
+
+      // Control canvas — always visible. Baseline for "what the layout
+      // SHOULD look like when the bug doesn't fire".
+      const rControl = new Rive({
+        canvas: canvasControl,
+        src: RIVE_SRC,
+        layout: new Layout({ fit: Fit.Layout, alignment: Alignment.Center }),
+        autoplay: true,
+        stateMachines: ["State Machine 1"],
+        onLoad: () => {
+          rControl.resizeDrawingSurfaceToCanvas();
+          snapshot("[control] onLoad", rControl, canvasControl);
+        },
+      });
+
+      // Buggy canvas — mounts inside display:none and resize() is called
+      // in onLoad while the canvas is still 0×0. Bug 2 fires here.
+      const r = new Rive({
+        canvas,
+        src: RIVE_SRC,
+        layout: new Layout({ fit: Fit.Layout, alignment: Alignment.Center }),
+        autoplay: true,
+        stateMachines: ["State Machine 1"],
+        onLoad: () => {
+          snapshot("[buggy] onLoad (before resize)", r, canvas);
+          // Realistic consumer pattern (matches layout_example/index.ts):
+          // call resizeDrawingSurfaceToCanvas() on load. With the canvas
+          // hidden, getBoundingClientRect() returns 0×0 — Bug 2 corrupts
+          // artboard.width/height to 0.
+          r.resizeDrawingSurfaceToCanvas();
+          snapshot("[buggy] onLoad (after resize) — Bug 2 fired", r, canvas);
+        },
+      });
+
+      document.getElementById("show").addEventListener("click", () => {
+        wrapper.classList.add("revealed");
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() =>
+            snapshot("[buggy] after reveal", r, canvas),
+          );
+        });
+      });
+
+      document.getElementById("shrinkW").addEventListener("click", () => {
+        // Width shrink 466 → 200. Non-zero → non-zero observer event.
+        // Bug 1 drops it: canvas backing stays at 466, CSS shrinks to 200,
+        // browser CSS-stretches the bitmap → visible horizontal squish.
+        canvas.style.width = "200px";
+        wrapper.style.width = "200px";
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() =>
+            snapshot(
+              "[buggy] shrink W to 200 — Bug 1 dropped delta",
+              r,
+              canvas,
+            ),
+          );
+        });
+      });
+
+      document.getElementById("shrinkH").addEventListener("click", () => {
+        // Height shrink 70 → 55 with canvas backing forced to match CSS
+        // (mimicking the lobby's `(window:resize)` host listener). The
+        // artboard stays stale (Bug 1) → artboard taller than canvas →
+        // Alignment.Center clips top + bottom of the design.
+        const newH = 55;
+        const dpr = window.devicePixelRatio || 1;
+        canvas.style.height = newH + "px";
+        wrapper.style.height = newH + "px";
+        canvas.height = dpr * newH;
+        canvas.width = dpr * canvas.clientWidth;
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() =>
+            snapshot(
+              `[buggy] shrink H to ${newH} — artboard stale, top/bottom clipped`,
+              r,
+              canvas,
+            ),
+          );
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -1145,8 +1145,14 @@ const audioManager = new AudioManager();
 
 // #region Observers
 
+type ObservedResizeCallback = (
+  hasZeroSize: boolean,
+  width?: number,
+  height?: number,
+) => void;
+
 type ObservedObject = {
-  onResize: Function;
+  onResize: ObservedResizeCallback;
   element: HTMLCanvasElement;
 };
 
@@ -1185,10 +1191,10 @@ class ObjectObservers {
    */
   private _onObservedEntry = (entry: ResizeObserverEntry) => {
     const observed = this._elementsMap.get(entry.target as HTMLCanvasElement);
-    if (observed !== null) {
-      observed.onResize(
-        entry.target.clientWidth == 0 || entry.target.clientHeight == 0,
-      );
+    if (observed != null) {
+      const width = entry.contentRect.width;
+      const height = entry.contentRect.height;
+      observed.onResize(width === 0 || height === 0, width, height);
     } else {
       this._resizeObserver.unobserve(entry.target);
     }
@@ -1199,7 +1205,7 @@ class ObjectObservers {
   };
 
   // Adds an observable element
-  public add(element: HTMLCanvasElement, onResize: Function) {
+  public add(element: HTMLCanvasElement, onResize: ObservedResizeCallback) {
     let observed: ObservedObject = {
       onResize,
       element,
@@ -1903,11 +1909,25 @@ export class Rive {
     this.volume = this._volume;
   }
 
-  private onCanvasResize = (hasZeroSize: boolean) => {
+  // Last dimensions seen by the ResizeObserver. Used to detect non-zero →
+  // non-zero dimension changes (which the legacy zero-toggle check ignored).
+  private _lastObservedWidth?: number;
+  private _lastObservedHeight?: number;
+
+  private onCanvasResize: ObservedResizeCallback = (
+    hasZeroSize,
+    width,
+    height,
+  ) => {
     const toggledDisplay = this._hasZeroSize !== hasZeroSize;
+    const dimensionsChanged =
+      width !== this._lastObservedWidth ||
+      height !== this._lastObservedHeight;
     this._hasZeroSize = hasZeroSize;
+    this._lastObservedWidth = width;
+    this._lastObservedHeight = height;
     if (!hasZeroSize) {
-      if (toggledDisplay) {
+      if (toggledDisplay || dimensionsChanged) {
         this.resizeDrawingSurfaceToCanvas();
       }
     } else if (!this._layout.maxX || !this._layout.maxY) {
@@ -2824,7 +2844,13 @@ export class Rive {
       this.resizeToCanvas();
       this.drawFrame();
 
-      if (this.layout.fit === Fit.Layout) {
+      if (this.layout.fit === Fit.Layout && width > 0 && height > 0) {
+        // Skip writing 0×0 into the artboard: when the canvas is inside a
+        // display:none ancestor at first measurement, getBoundingClientRect
+        // reports 0×0 and a blind write would corrupt the responsive layout
+        // state. Preserve the previously-correct (or design-time) artboard
+        // dimensions; a subsequent observer fire with non-zero dimensions
+        // will overwrite them with the right values.
         const scaleFactor = this._layout.layoutScaleFactor;
         this.artboard.width = width / scaleFactor;
         this.artboard.height = height / scaleFactor;

--- a/js/test/layout.test.ts
+++ b/js/test/layout.test.ts
@@ -2,6 +2,7 @@
 // which means there is no loading an external WASM file for tests
 import * as rc from "../src/rive_advanced.mjs";
 import * as rive from "../src/rive";
+import { pingPongRiveFileBuffer } from "./assets/bytes";
 
 // #region layout
 
@@ -123,6 +124,97 @@ test("layoutScaleFactor can be copied with overridden values", (): void => {
 
   expect(layout.fit).toBe(rive.Fit.Layout);
   expect(layout.layoutScaleFactor).toBe(3);
+});
+
+// #endregion
+
+// #region Fit.Layout responsiveness regressions
+
+// Test helper installed by test/setup.ts — fires a synthetic ResizeObserver
+// entry through the same code path the browser would use.
+declare const __fireResizeObserver: (
+  target: Element,
+  width: number,
+  height: number,
+) => void;
+
+// Drives the public ResizeObserver integration: when the canvas dimensions
+// change, Rive should re-fit its drawing surface.
+test("Rive re-fits the drawing surface on every non-zero canvas dimension change", (done) => {
+  const canvas = document.createElement("canvas");
+  const r = new rive.Rive({
+    canvas,
+    buffer: pingPongRiveFileBuffer,
+    autoplay: false,
+    layout: new rive.Layout({ fit: rive.Fit.Layout }),
+    onLoad: () => {
+      const resizeSpy = jest
+        .spyOn(r, "resizeDrawingSurfaceToCanvas")
+        .mockImplementation(() => {});
+
+      // Initial mount: canvas hidden → no re-fit.
+      __fireResizeObserver(canvas, 0, 0);
+      expect(resizeSpy).not.toHaveBeenCalled();
+
+      // Reveal at 466×70 → re-fit (zero → non-zero toggle).
+      __fireResizeObserver(canvas, 466, 70);
+      expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+      // Reflow to 451×70 → re-fit (the regression this patch addresses;
+      // previously dropped because hasZeroSize stayed false).
+      __fireResizeObserver(canvas, 451, 70);
+      expect(resizeSpy).toHaveBeenCalledTimes(2);
+
+      // Observer re-fires at identical dims → no re-fit.
+      __fireResizeObserver(canvas, 451, 70);
+      expect(resizeSpy).toHaveBeenCalledTimes(2);
+
+      resizeSpy.mockRestore();
+      r.cleanup();
+      done();
+    },
+  });
+});
+
+// Verifies that resizeDrawingSurfaceToCanvas is safe to call when the canvas
+// reports 0×0 (display:none-on-mount scenario): it must not overwrite the
+// artboard's existing width/height with zeros. Previously the Fit.Layout
+// branch blindly wrote 0/scaleFactor into the artboard, corrupting the
+// responsive layout state for the rest of the session.
+test("resizeDrawingSurfaceToCanvas preserves artboard dimensions when canvas is 0×0", (done) => {
+  const canvas = document.createElement("canvas");
+  const r = new rive.Rive({
+    canvas,
+    buffer: pingPongRiveFileBuffer,
+    autoplay: false,
+    layout: new rive.Layout({ fit: rive.Fit.Layout }),
+    onLoad: () => {
+      // Seed plausible artboard dimensions via the public setters,
+      // mimicking the design-time or previously-correct measurement.
+      r.artboardWidth = 376;
+      r.artboardHeight = 70;
+
+      jest.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+      r.resizeDrawingSurfaceToCanvas();
+
+      expect(r.artboardWidth).toBe(376);
+      expect(r.artboardHeight).toBe(70);
+
+      r.cleanup();
+      done();
+    },
+  });
 });
 
 // #endregion

--- a/js/test/setup.ts
+++ b/js/test/setup.ts
@@ -1,3 +1,45 @@
 window.AudioContext = jest.fn().mockImplementation(() => {
-    return {}
+  return {};
 });
+
+// jsdom doesn't ship a ResizeObserver. Provide one that captures the per-target
+// callback so tests can fire synthetic entries through the same code path the
+// browser would use.
+const resizeObserverCallbacks = new Map<Element, ResizeObserverCallback>();
+
+class TestResizeObserver implements ResizeObserver {
+  private readonly targets = new Set<Element>();
+  constructor(private readonly callback: ResizeObserverCallback) {}
+  public observe(target: Element): void {
+    this.targets.add(target);
+    resizeObserverCallbacks.set(target, this.callback);
+  }
+  public unobserve(target: Element): void {
+    this.targets.delete(target);
+    resizeObserverCallbacks.delete(target);
+  }
+  public disconnect(): void {
+    for (const target of this.targets) {
+      resizeObserverCallbacks.delete(target);
+    }
+    this.targets.clear();
+  }
+}
+
+(globalThis as any).ResizeObserver = TestResizeObserver;
+
+// Test helper: trigger the ResizeObserver callback registered for the given
+// target with a synthetic entry of the supplied dimensions.
+(globalThis as any).__fireResizeObserver = (
+  target: Element,
+  width: number,
+  height: number,
+): void => {
+  const callback = resizeObserverCallbacks.get(target);
+  if (!callback) return;
+  const entry = {
+    target,
+    contentRect: { width, height } as DOMRectReadOnly,
+  } as ResizeObserverEntry;
+  callback([entry], {} as ResizeObserver);
+};


### PR DESCRIPTION
## Summary

Two related bugs in `js/src/rive.ts` affect `Fit.Layout` consumers whose canvas mounts inside an unsettled or hidden layout (the common skeleton/loader pattern):

### Bug 1 — `Rive.onCanvasResize` ignores non-zero → non-zero dimension changes

`ObjectObservers._onObservedEntry` collapses every `ResizeObserverEntry` into a single `hasZeroSize` boolean, and `Rive.onCanvasResize` only triggers `resizeDrawingSurfaceToCanvas()` when that boolean toggles. Layout shifts that keep `hasZeroSize === false` on both sides (scrollbar appearance, sibling reflow, web font swap-in) are silently dropped, so `Fit.Layout` consumers see `artboard.width/height` drift stale.

### Bug 2 — `Rive.resizeDrawingSurfaceToCanvas` writes `0` into the artboard at `0×0`

When the canvas is inside a `display:none` ancestor, `getBoundingClientRect()` returns `0×0`. The `Fit.Layout` branch then writes `0 / scaleFactor` to `artboard.width` and `artboard.height`, corrupting the responsive layout state. The state machine commits child positions against the zero-dimension layout box; residue persists after the canvas later becomes visible.

The two bugs feed each other: Bug 2 introduces the corruption, Bug 1 prevents subsequent layout shifts from re-fitting the artboard back to canvas reality.

## Changes

### `js/src/rive.ts`

1. **Tighten `ObservedObject.onResize` type** from `Function` to a dedicated `ObservedResizeCallback = (hasZeroSize, width?, height?) => void`. No public API break — the new parameters are optional.
2. **`ObjectObservers._onObservedEntry`** forwards `entry.contentRect.width/height` to the callback (was: discarded). Also corrects a dead-code condition where `Map.get` was compared against `null` (it returns `undefined`).
3. **`Rive.onCanvasResize`** tracks the last observed dimensions in `_lastObservedWidth/Height` and triggers `resizeDrawingSurfaceToCanvas()` when either the zero-toggle OR a dimension delta occurs.
4. **`Rive.resizeDrawingSurfaceToCanvas`** guards the `Fit.Layout` artboard write on `width > 0 && height > 0`. When the canvas reports `0×0`, the artboard's previous (or design-time) dimensions are preserved; a subsequent observer fire with non-zero dimensions overwrites them with the right values.

### `js/test/setup.ts`

Adds a jsdom `ResizeObserver` polyfill that captures each instance's targets. jsdom doesn't ship one natively; previously the runtime fell back to a no-op `FakeResizeObserver` in tests, which meant resize behavior couldn't be unit-tested.

Also exposes a `__fireResizeObserver(target, width, height)` test helper that fires a synthetic entry through the same code path the browser would use — keeps tests on the public API.

### `js/test/layout.test.ts`

Two new tests, both public-API-only (no `as any` casts, no test-only exports from `rive.ts`):

- `Rive re-fits the drawing surface on every non-zero canvas dimension change` — exercises Bug 1's regression scenario end-to-end through the ResizeObserver integration.
- `resizeDrawingSurfaceToCanvas preserves artboard dimensions when canvas is 0×0` — exercises Bug 2's fix.

### `js/examples/_frameworks/fit_layout_zero_repro/` (new)

Side-by-side repro: a `control` canvas (always visible, baseline) next to a `buggy` canvas (mounts inside `display:none`, `resizeDrawingSurfaceToCanvas()` called in `onLoad`). On-page log captures `artboard.width/height` and canvas dimensions at each step.

Two entry points:
- **`standalone.html`** — uses `@rive-app/canvas@2.37.6` from unpkg. Opens immediately, no local build. Suitable as a reviewer-facing repro.
- **`index.html`** (`index.ts`, parcel-based) — consumes the local `npm/canvas_single` build. Verify the fix end-to-end after applying the patches and rebuilding.

Reuses `../layout_example/assets/layout_test.riv` — no asset duplication.

## How to verify

```bash
cd js
npm test                                  # both new tests pass
./build.sh -r canvas-single               # rebuild with the fix
cd examples/_frameworks/fit_layout_zero_repro
npm install && npm start                  # parcel example, open in browser
```

Walk through the buttons (`Reveal`, `Shrink WIDTH`, `Shrink HEIGHT`) and watch the on-page log. With the fix applied, the buggy canvas's artboard dimensions track the canvas through every transition. Without the fix, the artboard stays stuck at `0×0` (after the initial hidden-mount resize call) or at the previous measurement (after dimension deltas).

## Backwards compatibility

- `Rive.onCanvasResize`'s new `width` / `height` parameters are optional. Internal call sites that don't pass them keep working.
- `ObservedObject.onResize` is typed more strictly (`ObservedResizeCallback` instead of `Function`). Not part of the public API.
- First observer fire produces `dimensionsChanged === true` (`undefined → number`), matching today's first-fire behaviour where `toggledDisplay` was also true.
- No public type changes that consumers can observe.

## Why the bug is intermittent in real apps

Bug 2 is timing-dependent: it fires only when `resizeDrawingSurfaceToCanvas()` lands while the canvas's ancestor is still `display:none`. That depends on race conditions — `.riv` fetch latency, WASM init time, when the consumer's loading/skeleton transitions, etc. The same page hard-refreshed can hit or miss the race. Once Bug 2 fires, Bug 1 prevents recovery via subsequent layout shifts.

## Out of scope

There's a `// TODO: implement properly when we have instancing` in `Rive.draw()` pointing at the runtime-side artboard-reinit gap that makes the state-machine residue persistent. Out of scope for this PR — fix #2 prevents the residue from being introduced in the first place; fix #1 ensures the artboard re-fits on every subsequent layout shift.
