### PR TITLE
Fix: Bind GL context before deleting renderer on cleanup

### DIFF
--- a/wasm/js/webgl2_renderer.js
+++ b/wasm/js/webgl2_renderer.js
@@ -98,6 +98,14 @@ Module["onRuntimeInitialized"] = function () {
     renderer._gl = gl;
     var nativeDelete = renderer.delete;
     renderer.delete = function () {
+      // Re-bind our context before the native delete: it routes into glDelete*,
+      // which deref the *current* GLctx. At teardown another instance may have
+      // made a different context current or cleared it (GLctx undefined), so the
+      // deletes would throw "...reading 'deleteTexture'". isContextLost() can't
+      // catch this — the context isn't lost, just not current.
+      if (this._handle) {
+        GL.makeContextCurrent(this._handle);
+      }
       nativeDelete.call(this);
       GL.deleteContext(this._handle);
       this._handle = this._canvas = this._width = this._width = this._gl = null;


### PR DESCRIPTION
Hello :) 
Thank you for the time you'll take to review this!

## Problem
On SPA navigation, calling `Rive.cleanup()` after the canvas is detached throws
`Cannot read properties of undefined (reading 'deleteTexture')` (also `deleteBuffer`,
`deleteVertexArray`, `deleteFramebuffer`, `deleteRenderbuffer`, `deleteProgram`,
`deleteShader`). Nothing visibly breaks, but it's logged on every WebGL2 teardown and
is noisy in production telemetry.

## Why it happens
`cleanup()` → `deleteRiveRenderer()` → `renderer.delete()` routes into Emscripten's
`glDelete*` bindings, every one of which dereferences the **current** GL context
(`GLctx`). There is only one Emscripten module per page, so `GLctx` is a single
module-scope global shared by every Rive instance and the offscreen-atlas singleton.

When the first cleanup runs `GL.deleteContext(handle)` on the currently-active handle,
`GLctx` is left `undefined`. The next teardown's first `glDelete*` then dereferences
nothing and throws.

## Why the obvious guard is wrong
`getContext('webgl2').isContextLost()` / the `webglcontextlost` event do **not** fire for a
detached-but-not-lost canvas, so an `isContextLost()`-based guard returns `false` and still
crashes. The real signal is the absence of a *current* `GLctx`, which is not the same as a
browser-level lost context.

## The consumer's dilemma (why there's no userland workaround)
There is no safe time to tear down a WebGL2 instance on navigation:
- `cleanup()` **during** the rAF draw loop → `BindingError: Cannot pass deleted object as a
  pointer of type StateMachineInstance`.
- `cleanup()` **after** the canvas is detached → the undefined-`GLctx` deref above.

Consumers defer `cleanup()` to a microtask to dodge the first, which lands them in the
second. This PR fixes the second crash; the microtask-defer pattern remains the right
answer for the first, so the two mitigations are **complementary, not alternatives**.

## Fix
In the WebGL2 renderer's `delete` override (`wasm/js/webgl2_renderer.js`), make our own GL
context current **before** the native delete:

```js
renderer.delete = function () {
  if (this._handle) {
    GL.makeContextCurrent(this._handle);   // restore GLctx for the deletes below
  }
  nativeDelete.call(this);                 // glDelete* now target the right context
  GL.deleteContext(this._handle);
  this._handle = this._canvas = this._width = this._width = this._gl = null;
};
```

This is the same `GL.makeContextCurrent(this._handle)` call the renderer's `clear()` override
already issues every frame, so it is proven safe. Because the context is re-bound rather than
skipped, the GPU resources are **deterministically freed** (no leak) instead of relying on the
browser to reclaim them when the context is eventually destroyed. It is a no-op-equivalent in
the normal case where our context is already current.

## Live reproduction
Public StackBlitz: <https://stackblitz.com/edit/stackblitz-starters-b7oqesjq?file=src%2Fapp%2Frive-page%2Frive-page.component.ts>

Steps:
1. Open the project. Open the browser **console**.
2. Click **Rive page** in the header. Two `@rive-app/webgl2` instances mount, autoplay,
   and animate (`birb.riv` served via jsDelivr from this repo's own examples folder).
3. Default cleanup mode is `microtask` — the standard workaround the original consumer
   uses, with locally-captured refs so `cleanup()` actually runs (mirroring real
   production code).
4. Click **Home** **quickly** while the animations are running. Console prints:
   ```
   Cannot read properties of undefined (reading 'deleteTexture')
       at glDeleteTextures (rive.js:…)
       at rive.wasm:0x…
       …
   ```
5. Toggle to **sync** in the header and repeat — same crash, different path: confirms
   the bug isn't a quirk of microtask defer but of the renderer's `delete` cascade itself.

Stack: Angular 21.1 (standalone, zoneless, signals, lazy routes), `@rive-app/webgl2@latest`.
Note that the StackBlitz error appears *after* the new page has rendered, because the
microtask drains at the end of the navigation task — the same reason this bug shows up
prominently in production telemetry: the user never sees anything fail.

## Why the Jest suite isn't extended
This crash is WebGL2-specific. The repo's Jest harness runs in jsdom with
`jest-canvas-mock` and is wired to the **Canvas2D** variant (`canvas_advanced_single.mjs`)
— no real WebGL2, no `GLctx`. A regression test there can't reach the failing code path;
the public Angular repro above stands in as the verifiable artifact.
