### PR TITLE
feat(viewmodel): expose enumName in getProperties

### DIFF
--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -962,6 +962,7 @@ export declare class SMIInput {
 export declare type ViewModelProperty = {
   name: string;
   type: DataType;
+  enumName?: string;
 };
 
 export declare class ViewModelInstanceValue {

--- a/wasm/src/bindings.cpp
+++ b/wasm/src/bindings.cpp
@@ -264,6 +264,10 @@ emscripten::val buildProperties(std::vector<rive::PropertyData>& properties)
                 break;
             case rive::DataType::enumType:
                 val = "enumType";
+                if (!prop.enumName.empty())
+                {
+                    jsProp.set("enumName", prop.enumName);
+                }
                 break;
             case rive::DataType::trigger:
                 val = "trigger";


### PR DESCRIPTION
Surfaces the enum type name on view model properties returned by `getProperties()`, so consumers can generate TypeScript definitions without separately correlating against `File.enums()`.

Depends on rive-app/rive-runtime#106 which adds `enumName` to `PropertyData`.