### PR TITLE
Performance: Unbounded Memory Growth in MaxRecentSize

### DIFF
--- a/wasm/js/max_recent_size.js
+++ b/wasm/js/max_recent_size.js
@@ -16,7 +16,7 @@ function MaxRecentSize(milliseconds, bitShift) {
         // Set an eviction timer for the value 'size'.
         _map.set(size, setTimeout(function() {
             _map.delete(size);
-            if (_map.length == 0) {
+            if (_map.size == 0) {
                 _maxSize = -Infinity;
             } else if (size == _maxSize) {
                 _maxSize = Math.max(..._map.keys());


### PR DESCRIPTION
## Summary

Performance: Unbounded Memory Growth in MaxRecentSize

## Problem

**Severity**: `High` | **File**: `wasm/js/max_recent_size.js:L6`

The `MaxRecentSize` implementation uses a `Map` to track sizes and relies on `setTimeout` for eviction. If many unique sizes are pushed rapidly, the `Map` will grow large. Furthermore, `_map.length` is used to check the size of a Map object, but Map objects do not have a `.length` property (it will always be `undefined`), so `_maxSize` will never be reset to `-Infinity` when the map becomes empty.

## Solution

Use `_map.size` instead of `_map.length` to correctly track the number of entries in the Map. Consider adding a hard limit to the Map size or using an LRU cache to prevent unbounded memory growth.

## Changes

- `wasm/js/max_recent_size.js` (modified)