### PR TITLE
feat(viewmodel): expose viewModelName in getProperties

### DIFF
--- a/js/src/rive_advanced.mjs.d.ts
+++ b/js/src/rive_advanced.mjs.d.ts
@@ -1100,6 +1100,7 @@ export declare type ViewModelProperty = {
   name: string;
   type: DataType;
   enumName?: string;
+  viewModelName?: string;
 };
 
 export declare class ViewModelInstanceValue {

--- a/js/test/data_bind.test.ts
+++ b/js/test/data_bind.test.ts
@@ -53,6 +53,29 @@ test("Autobinds correctly to the right view model instance", (done) => {
   });
 });
 
+test("View model properties expose the name of the view model they reference", (done) => {
+  const canvas = document.createElement("canvas");
+  const r = new rive.Rive({
+    canvas: canvas,
+    buffer: loadFile("assets/data_bind_runtime_test.riv"),
+    autoplay: true,
+    autoBind: true,
+    onLoad: () => {
+      const properties = r.viewModelByName("vm1")?.properties;
+      expect(properties?.[0].type).toBe("viewModel");
+      expect(properties?.[0].viewModelName).toBe("vm2");
+      expect(properties?.[1].type).toBe("string");
+      expect(properties?.[1].viewModelName).toBeUndefined();
+
+      const instanceProperties = r.viewModelInstance?.properties;
+      expect(instanceProperties?.[0].viewModelName).toBe("vm2");
+      expect(instanceProperties?.[1].viewModelName).toBeUndefined();
+
+      done();
+    },
+  });
+});
+
 test("Binds the default view model instance correctly", (done) => {
   const canvas = document.createElement("canvas");
   const r = new rive.Rive({

--- a/wasm/src/bindings.cpp
+++ b/wasm/src/bindings.cpp
@@ -363,6 +363,10 @@ emscripten::val buildProperties(std::vector<rive::PropertyData>& properties)
                 break;
             case rive::DataType::viewModel:
                 val = "viewModel";
+                if (!prop.viewModelName.empty())
+                {
+                    jsProp.set("viewModelName", prop.viewModelName);
+                }
                 break;
             case rive::DataType::integer:
                 val = "integer";


### PR DESCRIPTION
Surfaces the name of the view model a `viewModel`-typed property references, so consumers generating TypeScript definitions can type nested property paths without instantiating the view model just to read the nested instance's name.

Depends on rive-app/rive-runtime#116 which adds `viewModelName` to `PropertyData`.