### PR TITLE
Revert "bug: check for animator before running animator.stop (#378)"

### DIFF
--- a/js/src/rive.ts
+++ b/js/src/rive.ts
@@ -3109,10 +3109,7 @@ export class Rive {
       });
       return;
     }
-    // If there is no artboard, this.animator will be undefined
-    if (this.animator) {
-      this.animator.stop(animationNames);
-    }
+    this.animator.stop(animationNames);
     if (this.eventCleanup) {
       this.eventCleanup();
     }


### PR DESCRIPTION
This reverts commit 432c3b740a855b48c2d34973e2a641fd2b2fada6.

Some code from upstream conflicted with this PR that was merged a few years back. We need to revert it to unblock the upstream push to this repo. Will get this specific change added upstream.